### PR TITLE
Fix Ez calculation near boundary

### DIFF
--- a/Source/ElectrostaticSolver.H
+++ b/Source/ElectrostaticSolver.H
@@ -26,6 +26,8 @@ void ComputeEfromPhi(MultiFab&                 PoissonPhi,
                 MultiFab&                      Ez,
                 amrex::GpuArray<amrex::Real, 3> prob_lo,
                 amrex::GpuArray<amrex::Real, 3> prob_hi,
+		amrex::Real const Phi_Bc_hi,
+                amrex::Real const Phi_Bc_lo,
                 const Geometry&                 geom);
 
 void InitializePermittivity(std::array< MultiFab, AMREX_SPACEDIM >& beta_face,

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -400,7 +400,9 @@ void main_main ()
     }
     
     amrex::Print() << "\n ========= Self-Consistent Initialization of P and Rho Done! ========== \n"<< iter << " iterations to obtain self consistent Phi with err = " << err << std::endl;
-    amrex::Print() << "\n ========= Advance Steps  ========== \n"<< std::endl;
+
+    // Calculate E from Phi
+    ComputeEfromPhi(PoissonPhi, Ex, Ey, Ez, prob_lo, prob_hi, Phi_Bc_hi, Phi_Bc_lo, geom);
 
     // Write a plotfile of the initial data if plot_int > 0
     if (plot_int > 0)
@@ -420,6 +422,8 @@ void main_main ()
         MultiFab::Copy(Plt, charge_den, 0, 10, 1, 0);
         WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge"}, geom, time, 0);
     }
+
+    amrex::Print() << "\n ========= Advance Steps  ========== \n"<< std::endl;
 
     for (int step = 1; step <= nsteps; ++step)
     {
@@ -678,7 +682,7 @@ void main_main ()
         }
 
         // Calculate E from Phi
-	ComputeEfromPhi(PoissonPhi, Ex, Ey, Ez, prob_lo, prob_hi, geom);
+	ComputeEfromPhi(PoissonPhi, Ex, Ey, Ez, prob_lo, prob_hi, Phi_Bc_hi, Phi_Bc_lo, geom);
 
 	Real step_stop_time = ParallelDescriptor::second() - step_strt_time;
         ParallelDescriptor::ReduceRealMax(step_stop_time);


### PR DESCRIPTION
This PR addresses issue #15 

Note that it only affects diagnostics, since Ex, Ey, and Ez fields are only computed for analysis.

I tested it with a previously run case (MFIM stack with only nonzero Pz) and made a vector plot of E as shown below
<img width="592" alt="Screen Shot 2022-10-27 at 4 37 55 PM" src="https://user-images.githubusercontent.com/89051199/198417221-dafe79dd-efe2-4cc5-a662-2a0f70d0f170.png">
