### PR TITLE
Charge density in Source/Drain/Channel

### DIFF
--- a/Exec/Examples/inputs_mfisfet_eb
+++ b/Exec/Examples/inputs_mfisfet_eb
@@ -8,7 +8,7 @@ domain.prob_hi =  16.e-9  16.e-9 16.e-9
 domain.n_cell = 64 64 32
 
 domain.max_grid_size = 64 64 32
-#domain.blocking_factor = 16 16 16
+domain.blocking_factor = 16 16 16
 
 domain.coord_sys = cartesian 
 
@@ -16,8 +16,8 @@ prob_type = 1
 
 TimeIntegratorOrder = 1
 
-nsteps = 1
-plot_int = 1
+nsteps = 1000
+plot_int = 100
 
 dt = 2.0e-13
 
@@ -45,27 +45,28 @@ boundary.lo = neu neu dir(0.0)
 domain.embedded_boundary = 1
 ebgeom.specify_input_using_eb2 = 0
 ebgeom.objects = MyGeom MyGeom1 MyGeom2
+#ebgeom.objects = MyGeom
 ebgeom.specify_inhomo_dir = 1
 
-##### box
+##### box (gate)
 MyGeom.geom_type = box
-MyGeom.box_lo = -16.0e-9  -16.0e-9 9.0e-9
-MyGeom.box_hi =  -6.0e-9   16.0e-9 10.0e-9
+MyGeom.box_lo = -12.0e-9  -16.0e-9 15.0e-9
+MyGeom.box_hi =  12.0e-9   16.0e-9 16.0e-9
 MyGeom.has_fluid_inside = 0
-MyGeom.surf_soln = 1.0 #V
+MyGeom.surf_soln = 0.0 #V
 
 
-##### box
+##### box (source)
 MyGeom1.geom_type = box
-MyGeom1.box_lo =   6.0e-9  -18.0e-9 9.0e-9
-MyGeom1.box_hi =  16.0e-9   18.0e-9 10.0e-9
+MyGeom1.box_lo =  -16.0e-9  -16.0e-9 0.0e-9
+MyGeom1.box_hi =  -15.0e-9   16.0e-9 9.0e-9
 MyGeom1.has_fluid_inside = 0
-MyGeom1.surf_soln = -1.0 #V
+MyGeom1.surf_soln = 0.0 #V
 
-##### box
+##### box (drain)
 MyGeom2.geom_type = box
-MyGeom2.box_lo =  -6.0e-9  -16.0e-9 15.0e-9
-MyGeom2.box_hi =   6.0e-9   16.0e-9 16.0e-9
+MyGeom2.box_lo =  15.0e-9  -16.0e-9 0.0e-9
+MyGeom2.box_hi =  16.0e-9   16.0e-9 9.0e-9
 MyGeom2.has_fluid_inside = 0
 MyGeom2.surf_soln = 0.0 #V
 
@@ -74,18 +75,23 @@ MyGeom2.surf_soln = 0.0 #V
 #################################
 
 SC_lo = -16.e-9 -16.e-9 0.e-9
-SC_hi =  16.e-9  16.e-9 10.e-9
+SC_hi =  16.e-9  16.e-9 9.e-9
 
-DE_lo = -6.e-9 -16.e-9 10.0e-9
-DE_hi =  6.e-9  16.e-9 11.0e-9
+Channel_lo = -12.e-9 -16.e-9 0.e-9
+Channel_hi =  12.e-9  16.e-9 9.e-9
 
-FE_lo = -6.e-9 -16.e-9 11.0e-9
-FE_hi =  6.e-9  16.e-9 15.e-9
+DE_lo = -12.e-9 -16.e-9 9.0e-9
+DE_hi =  12.e-9  16.e-9 10.0e-9
+
+FE_lo = -12.e-9 -16.e-9 10.0e-9
+FE_hi =  12.e-9  16.e-9 15.e-9
 
 #################################
 ###### MATERIAL PROPERTIES ######
 #################################
 
+acceptor_doping = 1.0e8
+donor_doping = 1.e14
 epsilon_0 = 8.85e-12
 epsilonX_fe = 24.0
 epsilonZ_fe = 24.0

--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -174,6 +174,8 @@ AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::SC_lo;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::DE_hi;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::FE_hi;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::SC_hi;
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::Channel_hi;
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::Channel_lo;
 
 // material parameters
 AMREX_GPU_MANAGED amrex::Real FerroX::epsilon_0;
@@ -201,6 +203,8 @@ AMREX_GPU_MANAGED amrex::Real FerroX::Ev;
 AMREX_GPU_MANAGED amrex::Real FerroX::q;
 AMREX_GPU_MANAGED amrex::Real FerroX::kb;
 AMREX_GPU_MANAGED amrex::Real FerroX::T;
+AMREX_GPU_MANAGED amrex::Real FerroX::acceptor_doping;
+AMREX_GPU_MANAGED amrex::Real FerroX::donor_doping;
 
 // P and Phi Bc
 AMREX_GPU_MANAGED amrex::Real FerroX::lambda;
@@ -321,6 +325,18 @@ void InitializeFerroXNamespace() {
          }
      }
 
+     if (pp.queryarr("Channel_lo",temp)) {
+         for (int i=0; i<AMREX_SPACEDIM; ++i) {
+             Channel_lo[i] = temp[i];
+         }
+     }
+
+     if (pp.queryarr("Channel_hi",temp)) {
+         for (int i=0; i<AMREX_SPACEDIM; ++i) {
+             Channel_hi[i] = temp[i];
+         }
+     }
+
      // For Silicon:
      // Nc = 2.8e25 m^-3
      // Nv = 1.04e25 m^-3
@@ -335,6 +351,10 @@ void InitializeFerroXNamespace() {
      kb = 1.38e-23; // Boltzmann constant
      T = 300; // Room Temp
 
+     acceptor_doping = 0.0;
+     pp.query("acceptor_doping",acceptor_doping);
+     donor_doping = 0.0;
+     pp.query("donor_doping",donor_doping);
 }
 
 

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -13,6 +13,8 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> DE_hi;
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FE_hi;
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> SC_hi;
+    extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> Channel_hi;
+    extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> Channel_lo;
 
     // material parameters
     extern AMREX_GPU_MANAGED amrex::Real epsilon_0;
@@ -40,6 +42,8 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED amrex::Real q;
     extern AMREX_GPU_MANAGED amrex::Real kb;
     extern AMREX_GPU_MANAGED amrex::Real T;
+    extern AMREX_GPU_MANAGED amrex::Real acceptor_doping;
+    extern AMREX_GPU_MANAGED amrex::Real donor_doping;
 
     // P and Phi Bc
     extern AMREX_GPU_MANAGED amrex::Real lambda;

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -90,15 +90,24 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
         });
         // Calculate charge density from Phi, Nc, Nv, Ec, and Ev
 
+	MultiFab acceptor_den(rho.boxArray(), rho.DistributionMap(), 1, 0);
+	MultiFab donor_den(rho.boxArray(), rho.DistributionMap(), 1, 0);
+
         const Array4<Real>& hole_den_arr = p_den.array(mfi);
         const Array4<Real>& e_den_arr = e_den.array(mfi);
         const Array4<Real>& charge_den_arr = rho.array(mfi);
+        const Array4<Real>& acceptor_den_arr = acceptor_den.array(mfi);
+        const Array4<Real>& donor_den_arr = donor_den.array(mfi);
+
 
         amrex::ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
+             Real x = prob_lo[0] + (i+0.5) * dx[0];
+             Real y = prob_lo[1] + (j+0.5) * dx[1];
              Real z = prob_lo[2] + (k+0.5) * dx[2];
 
-             if(z <= SC_hi[2]){ //SC region
+             //SC region
+             if (x <= SC_hi[0] + small && x >= SC_lo[0] - small && y <= SC_hi[1] + small && y >= SC_lo[1] - small && z <= SC_hi[2] + small && z >= SC_lo[2] - small) {
 
                   Real Phi = 0.5*(Ec + Ev); //eV
 //                hole_den_arr(i,j,k) = Nv*exp(-(Phi - Ev)*1.602e-19/(kb*T));
@@ -119,7 +128,16 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
                   Real FD_half_p = std::pow(exp(-eta_p) + xi_p, -1.0);
 
                   hole_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nv*FD_half_p;
-                  charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k));
+
+		  //If in channel, set acceptor doping, else (Source/Drain) set donor doping
+                  if (x <= Channel_hi[0] + small && x >= Channel_lo[0] - small && y <= Channel_hi[1] + small && y >= Channel_lo[1] - small && z <= Channel_hi[2] + small && z >= Channel_lo[2] - small) {
+		     acceptor_den_arr(i,j,k) = acceptor_doping; 
+	             donor_den_arr(i,j,k) = 0.0;
+		  } else { // Source / Drain
+		     acceptor_den_arr(i,j,k) = 0.0; 
+	             donor_den_arr(i,j,k) = donor_doping;
+		  }
+                  charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k) - acceptor_den_arr(i,j,k) + donor_den_arr(i,j,k));
 
              } else {
 


### PR DESCRIPTION
This PR adds the option to model the source, drain, and channel regions within the overall SC region by modifying the formula for charge density.

We now use the general form of rho as 
`rho = q(p - n - N_a  + N_d)` where 
`p` is hole density
`n` is electron density
`N_a` and `N_d` are the concentration of ionized acceptor and donor, respectively.

In the current implementation, channel is assumed to have non zero acceptor doping (p-type) and source/drain have non-zero donor doping (n-type) [based on  [Girish's paper](https://ieeexplore.ieee.org/document/9833284)