### PR TITLE
Material mask

### DIFF
--- a/Exec/Examples/inputs_mfis_eb
+++ b/Exec/Examples/inputs_mfis_eb
@@ -25,8 +25,8 @@ dt = 2.0e-13
 ###### POLARIZATION BOUNDARY CONDITIONS ####
 ############################################
 
-P_BC_flag_lo = 0
-P_BC_flag_hi = 1
+P_BC_flag_lo = 3 3 0
+P_BC_flag_hi = 3 3 1
 lambda = 3.0e-9
 
 ############################################
@@ -67,6 +67,9 @@ MyGeom.surf_soln = 0.0 #V
 
 SC_lo = -16.e-9 -16.e-9 0.e-9
 SC_hi =  16.e-9  16.e-9 10.e-9
+
+#SC_lo = -1. -1. -1.
+#SC_hi =  -1.  -1. -1.
 
 DE_lo = -16.e-9 -16.e-9 10.0e-9
 DE_hi =  16.e-9  16.e-9 11.0e-9

--- a/Exec/Examples/inputs_mfisfet_eb
+++ b/Exec/Examples/inputs_mfisfet_eb
@@ -86,6 +86,14 @@ DE_hi =  12.e-9  16.e-9 10.0e-9
 FE_lo = -12.e-9 -16.e-9 10.0e-9
 FE_hi =  12.e-9  16.e-9 15.e-9
 
+#FE:0.0, DE:1.0, Source/Drain:2.0, Channel:3.0
+my_constants.tiny = 1.e-16
+device_geom.device_geom_function(x,y,z) = "-1.*(x > -12.e-9 - tiny)*(x < 12.e-9 + tiny) * (y > -16.e-9 - tiny)*(y < 16.e-9 + tiny) * (z > 10.e-9 - tiny)*(z < 15.e-9 + tiny) 
+                                         + 1.*(x > -16.e-9 - tiny)*(x < 16.e-9 + tiny) * (y > -16.e-9 - tiny)*(y < 16.e-9 + tiny) * (z > 9.e-9 - tiny)*(z < 16.e-9 + tiny)
+                                         + 2.*(x > -16.e-9 - tiny)*(x < 16.e-9 + tiny) * (y > -16.e-9 - tiny)*(y < 16.e-9 + tiny) * (z > 0.e-9 - tiny)*(z < 9.e-9 + tiny)
+                                         + 1.*(x > -12.e-9 - tiny)*(x < 12.e-9 + tiny) * (y > -16.e-9 - tiny)*(y < 16.e-9 + tiny) * (z > 0.e-9 - tiny)*(z < 9.e-9 + tiny)"
+
+
 #################################
 ###### MATERIAL PROPERTIES ######
 #################################

--- a/Exec/Examples/inputs_mfisfet_eb
+++ b/Exec/Examples/inputs_mfisfet_eb
@@ -8,7 +8,7 @@ domain.prob_hi =  16.e-9  16.e-9 16.e-9
 domain.n_cell = 64 64 32
 
 domain.max_grid_size = 64 64 32
-#domain.blocking_factor = 16 16 16
+domain.blocking_factor = 16 16 16
 
 domain.coord_sys = cartesian 
 
@@ -16,8 +16,8 @@ prob_type = 1
 
 TimeIntegratorOrder = 1
 
-nsteps = 1
-plot_int = 1
+nsteps = 1000
+plot_int = 100
 
 dt = 2.0e-13
 
@@ -45,27 +45,28 @@ boundary.lo = neu neu dir(0.0)
 domain.embedded_boundary = 1
 ebgeom.specify_input_using_eb2 = 0
 ebgeom.objects = MyGeom MyGeom1 MyGeom2
+#ebgeom.objects = MyGeom
 ebgeom.specify_inhomo_dir = 1
 
-##### box
+##### box (gate)
 MyGeom.geom_type = box
-MyGeom.box_lo = -16.0e-9  -16.0e-9 9.0e-9
-MyGeom.box_hi =  -6.0e-9   16.0e-9 10.0e-9
+MyGeom.box_lo = -12.0e-9  -16.0e-9 15.0e-9
+MyGeom.box_hi =  12.0e-9   16.0e-9 16.0e-9
 MyGeom.has_fluid_inside = 0
-MyGeom.surf_soln = 1.0 #V
+MyGeom.surf_soln = 0.0 #V
 
 
-##### box
+##### box (source)
 MyGeom1.geom_type = box
-MyGeom1.box_lo =   6.0e-9  -18.0e-9 9.0e-9
-MyGeom1.box_hi =  16.0e-9   18.0e-9 10.0e-9
+MyGeom1.box_lo =  -16.0e-9  -16.0e-9 0.0e-9
+MyGeom1.box_hi =  -15.0e-9   16.0e-9 9.0e-9
 MyGeom1.has_fluid_inside = 0
-MyGeom1.surf_soln = -1.0 #V
+MyGeom1.surf_soln = 0.0 #V
 
-##### box
+##### box (drain)
 MyGeom2.geom_type = box
-MyGeom2.box_lo =  -6.0e-9  -16.0e-9 15.0e-9
-MyGeom2.box_hi =   6.0e-9   16.0e-9 16.0e-9
+MyGeom2.box_lo =  15.0e-9  -16.0e-9 0.0e-9
+MyGeom2.box_hi =  16.0e-9   16.0e-9 9.0e-9
 MyGeom2.has_fluid_inside = 0
 MyGeom2.surf_soln = 0.0 #V
 
@@ -74,18 +75,23 @@ MyGeom2.surf_soln = 0.0 #V
 #################################
 
 SC_lo = -16.e-9 -16.e-9 0.e-9
-SC_hi =  16.e-9  16.e-9 10.e-9
+SC_hi =  16.e-9  16.e-9 9.e-9
 
-DE_lo = -6.e-9 -16.e-9 10.0e-9
-DE_hi =  6.e-9  16.e-9 11.0e-9
+Channel_lo = -12.e-9 -16.e-9 0.e-9
+Channel_hi =  12.e-9  16.e-9 9.e-9
 
-FE_lo = -6.e-9 -16.e-9 11.0e-9
-FE_hi =  6.e-9  16.e-9 15.e-9
+DE_lo = -12.e-9 -16.e-9 9.0e-9
+DE_hi =  12.e-9  16.e-9 10.0e-9
+
+FE_lo = -12.e-9 -16.e-9 10.0e-9
+FE_hi =  12.e-9  16.e-9 15.e-9
 
 #################################
 ###### MATERIAL PROPERTIES ######
 #################################
 
+acceptor_doping = 1.0e8
+donor_doping = 1.e14
 epsilon_0 = 8.85e-12
 epsilonX_fe = 24.0
 epsilonZ_fe = 24.0

--- a/Source/FerroX.H
+++ b/Source/FerroX.H
@@ -113,6 +113,7 @@ private:
 
 
 void main_main (c_FerroX& rFerroX);
-void InitializeFerroXNamespace ();
+void InitializeFerroXNamespace (const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
+                                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
 #endif

--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -174,6 +174,8 @@ AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::SC_lo;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::DE_hi;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::FE_hi;
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::SC_hi;
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::Channel_hi;
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::Channel_lo;
 
 // material parameters
 AMREX_GPU_MANAGED amrex::Real FerroX::epsilon_0;
@@ -201,6 +203,8 @@ AMREX_GPU_MANAGED amrex::Real FerroX::Ev;
 AMREX_GPU_MANAGED amrex::Real FerroX::q;
 AMREX_GPU_MANAGED amrex::Real FerroX::kb;
 AMREX_GPU_MANAGED amrex::Real FerroX::T;
+AMREX_GPU_MANAGED amrex::Real FerroX::acceptor_doping;
+AMREX_GPU_MANAGED amrex::Real FerroX::donor_doping;
 
 // P and Phi Bc
 AMREX_GPU_MANAGED amrex::Real FerroX::lambda;
@@ -321,6 +325,18 @@ void InitializeFerroXNamespace() {
          }
      }
 
+     if (pp.queryarr("Channel_lo",temp)) {
+         for (int i=0; i<AMREX_SPACEDIM; ++i) {
+             Channel_lo[i] = temp[i];
+         }
+     }
+
+     if (pp.queryarr("Channel_hi",temp)) {
+         for (int i=0; i<AMREX_SPACEDIM; ++i) {
+             Channel_hi[i] = temp[i];
+         }
+     }
+
      // For Silicon:
      // Nc = 2.8e25 m^-3
      // Nv = 1.04e25 m^-3
@@ -335,6 +351,10 @@ void InitializeFerroXNamespace() {
      kb = 1.38e-23; // Boltzmann constant
      T = 300; // Room Temp
 
+     acceptor_doping = 0.0;
+     pp.query("acceptor_doping",acceptor_doping);
+     donor_doping = 0.0;
+     pp.query("donor_doping",donor_doping);
 }
 
 

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -13,6 +13,8 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> DE_hi;
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FE_hi;
     extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> SC_hi;
+    extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> Channel_hi;
+    extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> Channel_lo;
 
     // material parameters
     extern AMREX_GPU_MANAGED amrex::Real epsilon_0;
@@ -40,6 +42,8 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED amrex::Real q;
     extern AMREX_GPU_MANAGED amrex::Real kb;
     extern AMREX_GPU_MANAGED amrex::Real T;
+    extern AMREX_GPU_MANAGED amrex::Real acceptor_doping;
+    extern AMREX_GPU_MANAGED amrex::Real donor_doping;
 
     // P and Phi Bc
     extern AMREX_GPU_MANAGED amrex::Real lambda;

--- a/Source/Solver/ChargeDensity.H
+++ b/Source/Solver/ChargeDensity.H
@@ -10,7 +10,5 @@ void ComputeRho(MultiFab&      PoissonPhi,
                 MultiFab&      rho,
                 MultiFab&      e_den,
                 MultiFab&      p_den,
-                const          Geometry& geom,
-		const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
-                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
+                const MultiFab& MaterialMask);
 

--- a/Source/Solver/DerivativeAlgorithm.H
+++ b/Source/Solver/DerivativeAlgorithm.H
@@ -7,7 +7,7 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DphiDz (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const z, amrex::Real const z_hi, amrex::Real const z_lo, 
+    amrex::Real const z_hi, amrex::Real const z_lo, 
     int const i, int const j, int const k,  amrex::GpuArray<amrex::Real, 3> dx, 
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>const& prob_lo,
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>const& prob_hi) {
@@ -44,10 +44,10 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DPDx (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const x, amrex::Real const x_hi, amrex::Real const x_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
 ) {
-    if (FE_lo[0] > x_lo && FE_lo[0] <= x) { //FE lower boundary
+    if (mask(i-1,j,k) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[0] == 0){
             Real F_lo = 0.0;
@@ -72,7 +72,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (x_hi > FE_hi[0] && x <= FE_hi[0] ){ // FE higher boundary
+    } else if (mask(i+1,j,k) != 0.0 && mask(i,j,k) == 0.0){ // FE higher boundary
 
         if(P_BC_flag_hi[0] == 0){
             Real F_hi = 0.0;
@@ -97,7 +97,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (x_hi <= FE_hi[0] && x_lo >= FE_lo[0]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i+1,j,k) - F(i-1,j,k))/(2.*dx[0]);
 
     } else {
@@ -110,11 +110,11 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DPDy (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const y, amrex::Real const y_hi, amrex::Real const y_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
 ) {
 
-    if (FE_lo[1] > y_lo && FE_lo[1] <= y) { //FE lower boundary
+    if (mask(i,j-1,k) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[1] == 0){
             Real F_lo = 0.0;
@@ -139,7 +139,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (y_hi > FE_hi[1] && y <= FE_hi[1] ){ // FE higher boundary
+    } else if (mask(i,j+1,k) != 0.0 && mask(i,j,k) == 0.0){ // FE higher boundary
 
         if(P_BC_flag_hi[1] == 0){
             Real F_hi = 0.0;
@@ -164,7 +164,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (y_hi <= FE_hi[1] && y_lo >= FE_lo[1]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i,j+1,k) - F(i,j-1,k))/(2.*dx[1]);
 
     } else {
@@ -177,11 +177,11 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DPDz (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const z, amrex::Real const z_hi, amrex::Real const z_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
 ) {
 
-    if (FE_lo[2] > z_lo && FE_lo[2] <= z) { //FE lower boundary
+    if (mask(i,j,k-1) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[2] == 0){
             Real F_lo = 0.0;
@@ -203,7 +203,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (z_hi > FE_hi[2] && z <= FE_hi[2] ){ // FE higher boundary
+    } else if ( mask(i,j,k+1) != 0.0 && mask(i,j,k) == 0.0 ){ // FE higher boundary
 
         if(P_BC_flag_hi[2] == 0){
             Real F_hi = 0.0;
@@ -225,7 +225,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (z_hi <= FE_hi[2] && z_lo >= FE_lo[2]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i,j,k+1) - F(i,j,k-1))/(2.*dx[2]);
 
     } else {
@@ -259,11 +259,11 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DoubleDPDx (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const x, amrex::Real const x_hi, amrex::Real const x_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
     ) {
         
-    if (FE_lo[0] > x_lo && FE_lo[0] <= x) { //FE lower boundary
+    if (mask(i-1,j,k) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[0] == 0){
             Real F_lo = 0.0;
@@ -288,7 +288,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (x_hi > FE_hi[0] && x <= FE_hi[0] ){ // FE higher boundary
+    } else if ( mask(i+1,j,k) != 0.0 && mask(i,j,k) == 0.0 ){ // FE higher boundary
 
         if(P_BC_flag_hi[0] == 0){
             Real F_hi = 0.0;
@@ -313,7 +313,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (x_hi <= FE_hi[0] && x_lo >= FE_lo[0]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i+1,j,k) - 2.*F(i,j,k) + F(i-1,j,k)) / (dx[0]*dx[0]);  
 
     } else {
@@ -327,11 +327,11 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DoubleDPDy (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const y, amrex::Real const y_hi, amrex::Real const y_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
     ) {
         
-    if (FE_lo[1] > y_lo && FE_lo[1] <= y) { //FE lower boundary
+    if (mask(i,j-1,k) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[1] == 0){
             Real F_lo = 0.0;
@@ -356,7 +356,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (y_hi > FE_hi[1] && y <= FE_hi[1] ){ // FE higher boundary
+    } else if ( mask(i,j+1,k) != 0.0 && mask(i,j,k) == 0.0 ){ // FE higher boundary
 
         if(P_BC_flag_hi[1] == 0){
             Real F_hi = 0.0;
@@ -381,7 +381,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (y_hi <= FE_hi[1] && y_lo >= FE_lo[1]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i,j+1,k) - 2.*F(i,j,k) + F(i,j-1,k)) / (dx[1]*dx[1]);  
 
     } else {
@@ -394,11 +394,11 @@ using namespace FerroX;
  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real DoubleDPDz (
     amrex::Array4<amrex::Real> const& F,
-    amrex::Real const z, amrex::Real const z_hi, amrex::Real const z_lo, 
+    amrex::Array4<amrex::Real> const& mask,
     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx
     ) {
         
-    if (FE_lo[2] > z_lo && FE_lo[2] <= z) { //FE lower boundary
+    if (mask(i,j,k-1) != 0.0 && mask(i,j,k) == 0.0) { //FE lower boundary
       
         if(P_BC_flag_lo[2] == 0){
             Real F_lo = 0.0;
@@ -420,7 +420,7 @@ using namespace FerroX;
             return 0.0;
         }     
 
-    } else if (z_hi > FE_hi[2] && z <= FE_hi[2] ){ // FE higher boundary
+    } else if ( mask(i,j,k+1) != 0.0 && mask(i,j,k) == 0.0 ){ // FE higher boundary
 
         if(P_BC_flag_hi[2] == 0){
             Real F_hi = 0.0;
@@ -442,7 +442,7 @@ using namespace FerroX;
             return 0.0;
         }
                   
-    } else if (z_hi <= FE_hi[2] && z_lo >= FE_lo[2]) { // inside FE
+    } else if (mask(i,j,k) == 0.0) { // inside FE
         return (F(i,j,k+1) - 2.*F(i,j,k) + F(i,j,k-1)) / (dx[2]*dx[2]);  
 
     } else {

--- a/Source/Solver/ElectrostaticSolver.H
+++ b/Source/Solver/ElectrostaticSolver.H
@@ -45,6 +45,7 @@ void dF_dPhi(MultiFab&            alpha_cc,
              MultiFab&            rho,
              MultiFab&            e_den,
              MultiFab&            p_den,
+	     const MultiFab&      MaterialMask,
              const          Geometry& geom,
 	     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);

--- a/Source/Solver/ElectrostaticSolver.H
+++ b/Source/Solver/ElectrostaticSolver.H
@@ -29,13 +29,7 @@ void ComputeEfromPhi(MultiFab&                 PoissonPhi,
                 const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
 //mask based permittivity
-void InitializePermittivity(MultiFab& beta_cc, const MultiFab& MaterialMask, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell);
-
-//cell-centered permittivity
-void InitializePermittivity(MultiFab& beta_cc, const Geometry&  geom, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell);
-
-//face-centered permittivity
-void InitializePermittivity(std::array< MultiFab, AMREX_SPACEDIM >& beta_face, const Geometry&  geom, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
+void InitializePermittivity(std::array<std::array<amrex::LinOpBCType,AMREX_SPACEDIM>,2>& LinOpBCType_2d, MultiFab& beta_cc, const MultiFab& MaterialMask, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell, const Geometry& geom);
 
 void dF_dPhi(MultiFab&            alpha_cc,
              MultiFab&            PoissonRHS, 

--- a/Source/Solver/ElectrostaticSolver.H
+++ b/Source/Solver/ElectrostaticSolver.H
@@ -11,9 +11,8 @@ using namespace FerroX;
 void ComputePoissonRHS(MultiFab&               PoissonRHS, 
 		Array<MultiFab, AMREX_SPACEDIM> &P_old,
 		MultiFab&                      rho, 
-		const Geometry&                 geom,
-		const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
-                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
+		MultiFab&                      MaterialMask, 
+		const Geometry&                 geom);
 
 //void ComputeEfromPhi(MultiFab&                 PoissonPhi,
 //                MultiFab&                      Ex,
@@ -45,7 +44,7 @@ void dF_dPhi(MultiFab&            alpha_cc,
              MultiFab&            rho,
              MultiFab&            e_den,
              MultiFab&            p_den,
-	     const MultiFab&      MaterialMask,
+	     MultiFab&      MaterialMask,
              const          Geometry& geom,
 	     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);

--- a/Source/Solver/ElectrostaticSolver.H
+++ b/Source/Solver/ElectrostaticSolver.H
@@ -28,8 +28,14 @@ void ComputeEfromPhi(MultiFab&                 PoissonPhi,
                 const Geometry&                 geom,
                 const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                 const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
-	
+
+//mask based permittivity
+void InitializePermittivity(MultiFab& beta_cc, const MultiFab& MaterialMask, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell);
+
+//cell-centered permittivity
 void InitializePermittivity(MultiFab& beta_cc, const Geometry&  geom, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell);
+
+//face-centered permittivity
 void InitializePermittivity(std::array< MultiFab, AMREX_SPACEDIM >& beta_face, const Geometry&  geom, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
 void dF_dPhi(MultiFab&            alpha_cc,

--- a/Source/Solver/ElectrostaticSolver.cpp
+++ b/Source/Solver/ElectrostaticSolver.cpp
@@ -63,6 +63,7 @@ void dF_dPhi(MultiFab&            alpha_cc,
              MultiFab&            rho,
              MultiFab&            e_den,
              MultiFab&            p_den,
+	     const MultiFab&      MaterialMask,
              const          Geometry& geom,
 	     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi)
@@ -76,7 +77,7 @@ void dF_dPhi(MultiFab&            alpha_cc,
         PoissonPhi_plus_delta.plus(delta, 0, 1, 0); 
 
         // Calculate rho from Phi in SC region
-        ComputeRho(PoissonPhi_plus_delta, rho, e_den, p_den, geom, prob_lo, prob_hi);
+        ComputeRho(PoissonPhi, rho, e_den, p_den, MaterialMask);
 
         //Compute RHS of Poisson equation
         ComputePoissonRHS(PoissonRHS_phi_plus_delta, P_old, rho, geom, prob_lo, prob_hi);

--- a/Source/Solver/Initialization.H
+++ b/Source/Solver/Initialization.H
@@ -11,6 +11,7 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
                    MultiFab&   rho,
                    MultiFab&   e_den,
                    MultiFab&   p_den,
+		   const MultiFab& MaterialMask,
                    const       Geometry& geom,
 		   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                    const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);

--- a/Source/Solver/Initialization.H
+++ b/Source/Solver/Initialization.H
@@ -15,3 +15,8 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
 		   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                    const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
+void InitializeMaterialMask(MultiFab& MaterialMask,
+                            const Geometry& geom,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
+

--- a/Source/Solver/Initialization.H
+++ b/Source/Solver/Initialization.H
@@ -2,6 +2,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
 #include "FerroX.H"
+#include "Input/GeometryProperties/GeometryProperties.H"
 
 using namespace amrex;
 using namespace FerroX;
@@ -21,3 +22,4 @@ void InitializeMaterialMask(MultiFab& MaterialMask,
                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
+void InitializeMaterialMask(c_FerroX& rFerroX, MultiFab& MaterialMask);

--- a/Source/Solver/Initialization.H
+++ b/Source/Solver/Initialization.H
@@ -22,4 +22,4 @@ void InitializeMaterialMask(MultiFab& MaterialMask,
                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
 
-void InitializeMaterialMask(c_FerroX& rFerroX, MultiFab& MaterialMask);
+void InitializeMaterialMask(c_FerroX& rFerroX, const Geometry& geom, MultiFab& MaterialMask);

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -190,10 +190,11 @@ void InitializeMaterialMask(MultiFab& MaterialMask,
 	     }
         });
     }
+    MaterialMask.FillBoundary(geom.periodicity());
 }
 
 // initialization of mask (device geometry) with parser
-void InitializeMaterialMask(c_FerroX& rFerroX, MultiFab& MaterialMask)
+void InitializeMaterialMask(c_FerroX& rFerroX, const Geometry& geom, MultiFab& MaterialMask)
 { 
     auto& rGprop = rFerroX.get_GeometryProperties();
     Box const& domain = rGprop.geom.Domain();
@@ -232,8 +233,9 @@ void InitializeMaterialMask(c_FerroX& rFerroX, MultiFab& MaterialMask)
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             eXstatic_MFab_Util::ConvertParserIntoMultiFab_3vars(i,j,k,dx,real_box,iv,macro_parser,mask_arr);
-	    //printf("mask(i,j,k) = %f\n",mask_arr(i,j,k));
         });
+
     }
+	MaterialMask.FillBoundary(geom.periodicity());
 }
 

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -90,15 +90,24 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
         });
         // Calculate charge density from Phi, Nc, Nv, Ec, and Ev
 
+	MultiFab acceptor_den(rho.boxArray(), rho.DistributionMap(), 1, 0);
+	MultiFab donor_den(rho.boxArray(), rho.DistributionMap(), 1, 0);
+
         const Array4<Real>& hole_den_arr = p_den.array(mfi);
         const Array4<Real>& e_den_arr = e_den.array(mfi);
         const Array4<Real>& charge_den_arr = rho.array(mfi);
+        const Array4<Real>& acceptor_den_arr = acceptor_den.array(mfi);
+        const Array4<Real>& donor_den_arr = donor_den.array(mfi);
+
 
         amrex::ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
+             Real x = prob_lo[0] + (i+0.5) * dx[0];
+             Real y = prob_lo[1] + (j+0.5) * dx[1];
              Real z = prob_lo[2] + (k+0.5) * dx[2];
 
-             if(z <= SC_hi[2]){ //SC region
+             //SC region
+             if (x <= SC_hi[0] + small && x >= SC_lo[0] - small && y <= SC_hi[1] + small && y >= SC_lo[1] - small && z <= SC_hi[2] + small && z >= SC_lo[2] - small) {
 
                   Real Phi = 0.5*(Ec + Ev); //eV
 //                hole_den_arr(i,j,k) = Nv*exp(-(Phi - Ev)*1.602e-19/(kb*T));
@@ -119,7 +128,16 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
                   Real FD_half_p = std::pow(exp(-eta_p) + xi_p, -1.0);
 
                   hole_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nv*FD_half_p;
-                  charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k));
+
+		  //If in channel, set acceptor doping, else (Source/Drain) set donor doping
+                  if (x <= Channel_hi[0] + small && x >= Channel_lo[0] - small && y <= Channel_hi[1] + small && y >= Channel_lo[1] - small && z <= Channel_hi[2] + small && z >= Channel_lo[2] - small) {
+		     acceptor_den_arr(i,j,k) = acceptor_doping; 
+	             donor_den_arr(i,j,k) = 0.0;
+		  } else { // Source / Drain
+		     acceptor_den_arr(i,j,k) = 0.0; 
+	             donor_den_arr(i,j,k) = donor_doping;
+		  }
+                  charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k) - acceptor_den_arr(i,j,k) + donor_den_arr(i,j,k));
 
              } else {
 

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -165,7 +165,6 @@ void InitializeMaterialMask(MultiFab& MaterialMask,
 
         // extract dx from the geometry object
         GpuArray<Real,AMREX_SPACEDIM> dx = geom.CellSizeArray();
-        Real small = dx[2]*1.e-6;
 
         const Array4<Real>& mask = MaterialMask.array(mfi);
 
@@ -177,13 +176,13 @@ void InitializeMaterialMask(MultiFab& MaterialMask,
              Real z = prob_lo[2] + (k+0.5) * dx[2];
 
              //FE:0, DE:1, Source/Drain:2, Channel:3
-             if (x <= FE_hi[0] + small && x >= FE_lo[0] - small && y <= FE_hi[1] + small && y >= FE_lo[1] - small && z <= FE_hi[2] + small && z >= FE_lo[2] - small) {
+             if (x <= FE_hi[0] && x >= FE_lo[0] && y <= FE_hi[1] && y >= FE_lo[1] && z <= FE_hi[2] && z >= FE_lo[2]) {
                  mask(i,j,k) = 0.;
-             } else if (x <= DE_hi[0] + small && x >= DE_lo[0] - small && y <= DE_hi[1] + small && y >= DE_lo[1] - small && z <= DE_hi[2] + small && z >= DE_lo[2] - small) {
+             } else if (x <= DE_hi[0] && x >= DE_lo[0] && y <= DE_hi[1] && y >= DE_lo[1] && z <= DE_hi[2] && z >= DE_lo[2]) {
                  mask(i,j,k) = 1.;
-             } else if (x <= SC_hi[0] + small && x >= SC_lo[0] - small && y <= SC_hi[1] + small && y >= SC_lo[1] - small && z <= SC_hi[2] + small && z >= SC_lo[2] - small) {
+             } else if (x <= SC_hi[0] && x >= SC_lo[0] && y <= SC_hi[1] && y >= SC_lo[1] && z <= SC_hi[2] && z >= SC_lo[2]) {
                  mask(i,j,k) = 2.;
-                if (x <= Channel_hi[0] + small && x >= Channel_lo[0] - small && y <= Channel_hi[1] + small && y >= Channel_lo[1] - small && z <= Channel_hi[2] + small && z >= Channel_lo[2] - small){
+                if (x <= Channel_hi[0] && x >= Channel_lo[0] && y <= Channel_hi[1] && y >= Channel_lo[1] && z <= Channel_hi[2] && z >= Channel_lo[2]){
                     mask(i,j,k) = 3.;
                 }
              } else {

--- a/Source/Solver/TotalEnergyDensity.H
+++ b/Source/Solver/TotalEnergyDensity.H
@@ -10,6 +10,7 @@ void CalculateTDGL_RHS(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs,
                 Array<MultiFab, AMREX_SPACEDIM> &P_old,
                 MultiFab&                       PoissonPhi,
                 MultiFab&                       Gamma,
+                MultiFab&                       MaterialMask,
                 const Geometry& geom,
 		const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                 const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);

--- a/Source/Utils/FerroXUtils/FerroXUtil.H
+++ b/Source/Utils/FerroXUtils/FerroXUtil.H
@@ -22,10 +22,7 @@
 using namespace amrex;
 
 
-namespace FerroX_MFab_Util
+namespace FerroX_Util
 {
-void AverageFaceCenteredMultiFabToCellCenters(std::array< amrex::MultiFab,
-                                            AMREX_SPACEDIM >& fc_arr,
-                                            amrex::MultiFab& cc_arr);
-
+void Contains_sc(MultiFab& MaterialMask, bool& contains_SC);
 }

--- a/Source/Utils/FerroXUtils/FerroXUtil.cpp
+++ b/Source/Utils/FerroXUtils/FerroXUtil.cpp
@@ -9,26 +9,33 @@
 using namespace amrex;
 
 
-void FerroX_MFab_Util::AverageFaceCenteredMultiFabToCellCenters(std::array< amrex::MultiFab,
-                                            AMREX_SPACEDIM >& fc_arr,
-                                            amrex::MultiFab& cc_arr)
+void FerroX_Util::Contains_sc(MultiFab& MaterialMask, bool& contains_SC)
 {
 
-    for (MFIter mfi(cc_arr); mfi.isValid(); ++mfi)
-    {
-        const Array4<Real> & cc = cc_arr.array(mfi);
-        const Array4<Real> & facex = fc_arr[0].array(mfi);
-        const Array4<Real> & facey = fc_arr[1].array(mfi);
-        const Array4<Real> & facez = fc_arr[2].array(mfi);
+	int has_SC = 0;
 
-	const Box& bx = mfi.validbox();
-        amrex::ParallelFor(bx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cc(i,j,k) = 0.5*(facex(i,j,k)+facex(i+1,j,k));
-            //cc(i,j,k) = 0.5*(facey(i,j,k)+facey(i,j+1,k));
-            //cc(i,j,k) = 0.5*(facez(i,j,k)+facez(i,j,k+1));
-        });
-    }
+        for ( MFIter mfi(MaterialMask, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
+            const Box& bx = mfi.validbox();
+            const auto lo = amrex::lbound(bx);
+            const auto hi = amrex::ubound(bx);
+
+            const Array4<Real>& mask = MaterialMask.array(mfi);
+
+            for (auto k = lo.z; k <= hi.z; ++k) {
+            for (auto j = lo.y; j <= hi.y; ++j) {
+            for (auto i = lo.x; i <= hi.x; ++i) {
+                  if (mask(i,j,k) >= 2.0) {
+                          has_SC = 1;
+                  }
+            }
+            }
+            }
+
+        } // end MFIter
+
+       // parallel reduce max has_SC
+       ParallelDescriptor::ReduceIntMax(has_SC);
+ 
+       if(has_SC == 1) contains_SC = true;
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -114,11 +114,11 @@ void main_main (c_FerroX& rFerroX)
     MultiFab hole_den(ba, dm, 1, 0);
     MultiFab e_den(ba, dm, 1, 0);
     MultiFab charge_den(ba, dm, 1, 0);
-    MultiFab MaterialMask(ba, dm, 1, 0);
+    MultiFab MaterialMask(ba, dm, 1, 1);
 
     //Initialize material mask
     //InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
-    InitializeMaterialMask(rFerroX, MaterialMask);
+    InitializeMaterialMask(rFerroX, geom, MaterialMask);
 
     //Solver for Poisson equation
     LPInfo info;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -118,7 +118,8 @@ void main_main (c_FerroX& rFerroX)
     MultiFab MaterialMask(ba, dm, 1, 0);
 
     //Initialize material mask
-    InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
+    //InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
+    InitializeMaterialMask(rFerroX, MaterialMask);
 
     //Solver for Poisson equation
     LPInfo info;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -252,7 +252,7 @@ void main_main (c_FerroX& rFerroX)
 	//Compute RHS of Poisson equation
 	ComputePoissonRHS(PoissonRHS, P_old, charge_den, geom, prob_lo, prob_hi);
 
-        dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+        dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
         ComputePoissonRHS_Newton(PoissonRHS, PoissonPhi, alpha_cc); 
 
@@ -269,7 +269,7 @@ void main_main (c_FerroX& rFerroX)
 	PoissonPhi.FillBoundary(geom.periodicity());
 	
         // Calculate rho from Phi in SC region
-        ComputeRho(PoissonPhi, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+        ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
         
 	if (SC_hi[2] <= 0.) {
             // no semiconductor region; set error to zero so the while loop terminates
@@ -359,7 +359,7 @@ void main_main (c_FerroX& rFerroX)
             // Compute RHS of Poisson equation
             ComputePoissonRHS(PoissonRHS, P_new_pre, charge_den, geom, prob_lo, prob_hi);
 
-            dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new_pre, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+            dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new_pre, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
             ComputePoissonRHS_Newton(PoissonRHS, PoissonPhi, alpha_cc); 
 
@@ -377,7 +377,7 @@ void main_main (c_FerroX& rFerroX)
 	    PoissonPhi.FillBoundary(geom.periodicity());
             
 	    // Calculate rho from Phi in SC region
-            ComputeRho(PoissonPhi, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+            ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
             if (SC_hi[2] <= 0.) {
                 // no semiconductor region; set error to zero so the while loop terminates
@@ -428,7 +428,7 @@ void main_main (c_FerroX& rFerroX)
                 // Compute RHS of Poisson equation
                 ComputePoissonRHS(PoissonRHS, P_new, charge_den, geom, prob_lo, prob_hi);
 
-                dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+                dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
                 ComputePoissonRHS_Newton(PoissonRHS, PoissonPhi, alpha_cc); 
 
@@ -446,7 +446,7 @@ void main_main (c_FerroX& rFerroX)
 	        PoissonPhi.FillBoundary(geom.periodicity());
 	
                 // Calculate rho from Phi in SC region
-                ComputeRho(PoissonPhi, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+                ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
                 if (SC_hi[2] <= 0.) {
                     // no semiconductor region; set error to zero so the while loop terminates
@@ -544,7 +544,7 @@ void main_main (c_FerroX& rFerroX)
                // Compute RHS of Poisson equation
                ComputePoissonRHS(PoissonRHS, P_old, charge_den, geom, prob_lo, prob_hi);
 
-               dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+               dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
                ComputePoissonRHS_Newton(PoissonRHS, PoissonPhi, alpha_cc); 
 
@@ -562,7 +562,7 @@ void main_main (c_FerroX& rFerroX)
 	       PoissonPhi.FillBoundary(geom.periodicity());
 	
                // Calculate rho from Phi in SC region
-               ComputeRho(PoissonPhi, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+               ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
                if (SC_hi[2] <= 0.) {
                    // no semiconductor region; set error to zero so the while loop terminates

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -45,10 +45,6 @@ void main_main (c_FerroX& rFerroX)
 
     Real total_step_strt_time = ParallelDescriptor::second();
 
-    // read in inputs file
-    InitializeFerroXNamespace();
-
-
     auto& rGprop = rFerroX.get_GeometryProperties();
     auto& geom = rGprop.geom;
     auto& ba = rGprop.ba;
@@ -57,6 +53,9 @@ void main_main (c_FerroX& rFerroX)
     auto& prob_lo = rGprop.prob_lo;
     auto& prob_hi = rGprop.prob_hi;
     auto& n_cell = rGprop.n_cell;
+
+    // read in inputs file
+    InitializeFerroXNamespace(prob_lo, prob_hi);
 
     int inc_step = 1000;
 
@@ -152,11 +151,8 @@ void main_main (c_FerroX& rFerroX)
                  beta_face[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
                  beta_face[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
 
-    // set face-centered beta coefficient to 
-    // epsilon values in SC, FE, and DE layers
-    //InitializePermittivity(beta_face, geom, prob_lo, prob_hi); //face-centered
-    //InitializePermittivity(beta_cc, geom, prob_lo, prob_hi, n_cell); // cell-centered
-    InitializePermittivity(beta_cc, MaterialMask, n_cell); //mask based
+    // set cell-centered beta coefficient to permittivity based on mask
+    InitializePermittivity(LinOpBCType_2d, beta_cc, MaterialMask, n_cell, geom);
     eXstatic_MFab_Util::AverageCellCenteredMultiFabToCellFaces(beta_cc, beta_face);
 
     int amrlev = 0; //refers to the setcoarsest level of the solve

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -238,7 +238,8 @@ void main_main (c_FerroX& rFerroX)
 
     // INITIALIZE P in FE and rho in SC regions
 
-    InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+    //InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);//old
+    InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);//mask based
     
 
     //Obtain self consisten Phi and rho

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -250,7 +250,7 @@ void main_main (c_FerroX& rFerroX)
     while(err > tol){
    
 	//Compute RHS of Poisson equation
-	ComputePoissonRHS(PoissonRHS, P_old, charge_den, geom, prob_lo, prob_hi);
+	ComputePoissonRHS(PoissonRHS, P_old, charge_den, MaterialMask, geom);
 
         dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
@@ -328,7 +328,7 @@ void main_main (c_FerroX& rFerroX)
         Real step_strt_time = ParallelDescriptor::second();
 
         // compute f^n = f(P^n,Phi^n)
-        CalculateTDGL_RHS(GL_rhs, P_old, PoissonPhi, Gamma, geom, prob_lo, prob_hi);
+        CalculateTDGL_RHS(GL_rhs, P_old, PoissonPhi, Gamma, MaterialMask, geom, prob_lo, prob_hi);
 
         // P^{n+1,*} = P^n + dt * f^n
         for (int i = 0; i < 3; i++){
@@ -357,7 +357,7 @@ void main_main (c_FerroX& rFerroX)
         while(err > tol){
    
             // Compute RHS of Poisson equation
-            ComputePoissonRHS(PoissonRHS, P_new_pre, charge_den, geom, prob_lo, prob_hi);
+            ComputePoissonRHS(PoissonRHS, P_new_pre, charge_den, MaterialMask, geom);
 
             dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new_pre, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
@@ -411,7 +411,7 @@ void main_main (c_FerroX& rFerroX)
         } else {
         
             // compute f^{n+1,*} = f(P^{n+1,*},Phi^{n+1,*})
-            CalculateTDGL_RHS(GL_rhs_pre, P_new_pre, PoissonPhi, Gamma, geom, prob_lo, prob_hi);
+            CalculateTDGL_RHS(GL_rhs_pre, P_new_pre, PoissonPhi, Gamma, MaterialMask, geom, prob_lo, prob_hi);
 
             // P^{n+1} = P^n + dt/2 * f^n + dt/2 * f^{n+1,*}
             for (int i = 0; i < 3; i++){
@@ -426,7 +426,7 @@ void main_main (c_FerroX& rFerroX)
             while(err > tol){
    
                 // Compute RHS of Poisson equation
-                ComputePoissonRHS(PoissonRHS, P_new, charge_den, geom, prob_lo, prob_hi);
+                ComputePoissonRHS(PoissonRHS, P_new, charge_den, MaterialMask, geom);
 
                 dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_new, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 
@@ -542,7 +542,7 @@ void main_main (c_FerroX& rFerroX)
            while(err > tol){
    
                // Compute RHS of Poisson equation
-               ComputePoissonRHS(PoissonRHS, P_old, charge_den, geom, prob_lo, prob_hi);
+               ComputePoissonRHS(PoissonRHS, P_old, charge_den, MaterialMask, geom);
 
                dF_dPhi(alpha_cc, PoissonRHS, PoissonPhi, P_old, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -116,6 +116,8 @@ void main_main (c_FerroX& rFerroX)
     MultiFab charge_den(ba, dm, 1, 0);
     MultiFab MaterialMask(ba, dm, 1, 0);
 
+    //Initialize material mask
+    InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
 
     //Solver for Poisson equation
     LPInfo info;
@@ -145,8 +147,9 @@ void main_main (c_FerroX& rFerroX)
 
     // set face-centered beta coefficient to 
     // epsilon values in SC, FE, and DE layers
-    //InitializePermittivity(beta_face, geom, prob_lo, prob_hi);
-    InitializePermittivity(beta_cc, geom, prob_lo, prob_hi, n_cell);
+    //InitializePermittivity(beta_face, geom, prob_lo, prob_hi); //face-centered
+    //InitializePermittivity(beta_cc, geom, prob_lo, prob_hi, n_cell); // cell-centered
+    InitializePermittivity(beta_cc, MaterialMask, n_cell); //mask based
     eXstatic_MFab_Util::AverageCellCenteredMultiFabToCellFaces(beta_cc, beta_face);
 
     int amrlev = 0; //refers to the setcoarsest level of the solve
@@ -237,8 +240,6 @@ void main_main (c_FerroX& rFerroX)
 
     InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
     
-    //Initialize material mask
-    InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
 
     //Obtain self consisten Phi and rho
     Real tol = 1.e-5;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -114,6 +114,7 @@ void main_main (c_FerroX& rFerroX)
     MultiFab hole_den(ba, dm, 1, 0);
     MultiFab e_den(ba, dm, 1, 0);
     MultiFab charge_den(ba, dm, 1, 0);
+    MultiFab MaterialMask(ba, dm, 1, 0);
 
 
     //Solver for Poisson equation
@@ -127,9 +128,9 @@ void main_main (c_FerroX& rFerroX)
     bool some_constant_inhomogeneous_boundaries = false;
 
 #ifdef AMREX_USE_EB
-    MultiFab Plt(ba, dm, 12, 0,  MFInfo(), *rGprop.pEB->p_factory_union);
+    MultiFab Plt(ba, dm, 13, 0,  MFInfo(), *rGprop.pEB->p_factory_union);
 #else    
-    MultiFab Plt(ba, dm, 12, 0);
+    MultiFab Plt(ba, dm, 13, 0);
 #endif
 
     SetPoissonBC(rFerroX, LinOpBCType_2d, all_homogeneous_boundaries, some_functionbased_inhomogeneous_boundaries, some_constant_inhomogeneous_boundaries);
@@ -235,6 +236,9 @@ void main_main (c_FerroX& rFerroX)
     // INITIALIZE P in FE and rho in SC regions
 
     InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);
+    
+    //Initialize material mask
+    InitializeMaterialMask(MaterialMask, geom, prob_lo, prob_hi);
 
     //Obtain self consisten Phi and rho
     Real tol = 1.e-5;
@@ -307,10 +311,11 @@ void main_main (c_FerroX& rFerroX)
         MultiFab::Copy(Plt, e_den, 0, 9, 1, 0);
         MultiFab::Copy(Plt, charge_den, 0, 10, 1, 0);
         MultiFab::Copy(Plt, beta_cc, 0, 11, 1, 0);
+        MultiFab::Copy(Plt, MaterialMask, 0, 12, 1, 0);
 #ifdef AMREX_USE_EB
-	amrex::EB_WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon"}, geom, time, 0);
+	amrex::EB_WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon", "mask"}, geom, time, step);
 #else
-	amrex::WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon"}, geom, time, 0);
+	amrex::WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon", "mask"}, geom, time, step);
 #endif
     }
 
@@ -501,10 +506,11 @@ void main_main (c_FerroX& rFerroX)
             MultiFab::Copy(Plt, charge_den, 0, 10, 1, 0);
 
             MultiFab::Copy(Plt, beta_cc, 0, 11, 1, 0);
+            MultiFab::Copy(Plt, MaterialMask, 0, 12, 1, 0);
 #ifdef AMREX_USE_EB
-	    amrex::EB_WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon"}, geom, time, step);
+	    amrex::EB_WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon", "mask"}, geom, time, step);
 #else
-	    amrex::WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon"}, geom, time, step);
+	    amrex::WriteSingleLevelPlotfile(pltfile, Plt, {"Px","Py","Pz","Phi","PoissonRHS","Ex","Ey","Ez","holes","electrons","charge","epsilon", "mask"}, geom, time, step);
 #endif
         }
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -18,6 +18,7 @@
 #include "Utils/SelectWarpXUtils/WarpXUtil.H"
 #include "Utils/SelectWarpXUtils/WarpXProfilerWrapper.H"
 #include "Utils/eXstaticUtils/eXstaticUtil.H"
+#include "Utils/FerroXUtils/FerroXUtil.H"
 
 
 
@@ -128,6 +129,11 @@ void main_main (c_FerroX& rFerroX)
     bool all_homogeneous_boundaries = true;
     bool some_functionbased_inhomogeneous_boundaries = false;
     bool some_constant_inhomogeneous_boundaries = false;
+ 
+    bool contains_SC = false;
+
+    FerroX_Util::Contains_sc(MaterialMask, contains_SC);
+    amrex::Print() << "contains_SC = " << contains_SC << "\n";
 
 #ifdef AMREX_USE_EB
     MultiFab Plt(ba, dm, 13, 0,  MFInfo(), *rGprop.pEB->p_factory_union);
@@ -271,7 +277,7 @@ void main_main (c_FerroX& rFerroX)
         // Calculate rho from Phi in SC region
         ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
         
-	if (SC_hi[2] <= 0.) {
+	if (contains_SC == 0) {
             // no semiconductor region; set error to zero so the while loop terminates
             err = 0.;
         } else {
@@ -379,7 +385,7 @@ void main_main (c_FerroX& rFerroX)
 	    // Calculate rho from Phi in SC region
             ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
-            if (SC_hi[2] <= 0.) {
+            if (contains_SC == 0) {
                 // no semiconductor region; set error to zero so the while loop terminates
                 err = 0.;
             } else {
@@ -448,7 +454,7 @@ void main_main (c_FerroX& rFerroX)
                 // Calculate rho from Phi in SC region
                 ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
-                if (SC_hi[2] <= 0.) {
+                if (contains_SC == 0) {
                     // no semiconductor region; set error to zero so the while loop terminates
                     err = 0.;
                 } else {
@@ -564,7 +570,7 @@ void main_main (c_FerroX& rFerroX)
                // Calculate rho from Phi in SC region
                ComputeRho(PoissonPhi, charge_den, e_den, hole_den, MaterialMask);
 
-               if (SC_hi[2] <= 0.) {
+               if (contains_SC == 0) {
                    // no semiconductor region; set error to zero so the while loop terminates
                    err = 0.;
                } else {


### PR DESCRIPTION
This PR creates a mask Multifab filled with numbers based on material type.

```
FE: 0.0
DE: 1.0
Source/Drain: 2.0
Channel: 3.0
```
Results of https://github.com/AMReX-Microelectronics/FerroX/blob/development/Exec/Examples/inputs_mfisfet_eb
give same results as before masks were introduced.
<img width="729" alt="Screen Shot 2022-12-21 at 6 51 04 PM" src="https://user-images.githubusercontent.com/89051199/209044973-6fddf35c-452b-4b72-b225-94212851e64e.png">

