### PR TITLE
add criterion for checking steady state and accordingly fix the voltage sweep approach

### DIFF
--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -220,6 +220,14 @@ AMREX_GPU_MANAGED int FerroX::TimeIntegratorOrder;
 
 AMREX_GPU_MANAGED amrex::Real FerroX::delta;
 
+AMREX_GPU_MANAGED int FerroX::voltage_sweep;
+AMREX_GPU_MANAGED int FerroX::inc_step;
+AMREX_GPU_MANAGED amrex::Real FerroX::Phi_Bc_lo;
+AMREX_GPU_MANAGED amrex::Real FerroX::Phi_Bc_hi;
+AMREX_GPU_MANAGED amrex::Real FerroX::Phi_Bc_inc;
+AMREX_GPU_MANAGED amrex::Real FerroX::Phi_Bc_hi_max;
+AMREX_GPU_MANAGED amrex::Real FerroX::phi_tolerance;
+
 void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi) {
 
@@ -285,6 +293,28 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
 
      delta = 1.e-6;
      pp.query("delta",delta);
+
+     voltage_sweep = 0; //0 means OFF, 1 means ON. Default to 0, that is do voltage sweep only when specified.
+     pp.query("voltage_sweep",voltage_sweep);
+
+     inc_step = -1;
+     pp.query("inc_step",inc_step);
+
+     Phi_Bc_hi = 0.;
+     pp.query("Phi_Bc_hi",Phi_Bc_hi);
+
+     Phi_Bc_lo = 0.;
+     pp.query("Phi_Bc_lo",Phi_Bc_lo);
+
+     Phi_Bc_inc = 0.;
+     pp.query("Phi_Bc_inc",Phi_Bc_inc);
+
+     Phi_Bc_hi_max = 0.;
+     pp.query("Phi_Bc_hi_max",Phi_Bc_hi_max);
+
+     phi_tolerance = 1.e-7;
+     pp.query("phi_tolerance",phi_tolerance);
+
 
      //stack dimensions in 3D. This is an alternate way of initializing the device geometry, which works in simpler scenarios.
      //A more general way of initializing device geometry is accomplished through masks which use function parsers

--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -251,6 +251,10 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
          }
      }
 
+     if(P_BC_flag_lo[2] == 3 || P_BC_flag_hi[2] == 3){
+       amrex::Warning("This boundary condition does not represent the accurate physical picture!!");
+     }
+
      pp.get("TimeIntegratorOrder",TimeIntegratorOrder);
 
      pp.get("prob_type", prob_type);

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -59,4 +59,16 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED int TimeIntegratorOrder;
 
     extern AMREX_GPU_MANAGED amrex::Real delta;
+
+    //Params related to voltage sweep
+    extern AMREX_GPU_MANAGED int voltage_sweep;
+    extern AMREX_GPU_MANAGED int inc_step;
+    extern AMREX_GPU_MANAGED amrex::Real Phi_Bc_lo;
+    extern AMREX_GPU_MANAGED amrex::Real Phi_Bc_hi;
+    extern AMREX_GPU_MANAGED amrex::Real Phi_Bc_inc;
+    extern AMREX_GPU_MANAGED amrex::Real Phi_Bc_hi_max;
+    extern AMREX_GPU_MANAGED amrex::Real phi_tolerance;
+
+
+
 }

--- a/Source/Solver/DerivativeAlgorithm.H
+++ b/Source/Solver/DerivativeAlgorithm.H
@@ -198,6 +198,9 @@ using namespace FerroX;
         } else if (P_BC_flag_lo[2] == 2){
             return ( - F(i,j,k) + F(i,j,k+1))/(2.*dx[2]); //dPdz = 0.
 
+        } else if (P_BC_flag_lo[2] == 3){
+            return ( - F(i,j,k-1) + F(i,j,k+1))/(2.*dx[2]); //No BC
+
         } else {
             amrex::Abort("Wrong flag of the lower polarization boundary condition!!");
             return 0.0;
@@ -219,6 +222,9 @@ using namespace FerroX;
 
         } else if (P_BC_flag_hi[2] == 2){
             return (F(i,j,k) - F(i,j,k-1))/(2.*dx[2]); //dPdz = 0.
+
+        } else if (P_BC_flag_hi[2] == 3){
+            return (0. - F(i,j,k-1))/(2.*dx[2]); //No BC
 
         } else {
             amrex::Abort("Wrong flag of the higher polarization boundary condition!!");
@@ -415,6 +421,9 @@ using namespace FerroX;
         } else if (P_BC_flag_lo[2] == 2){
             return ( - F(i,j,k) + F(i,j,k+1))/dx[2]/dx[2];//dPdz = 0.
 
+	} else if (P_BC_flag_lo[2] == 3){
+            return ( F(i,j,k-1) - 2.*F(i,j,k) + F(i,j,k+1))/dx[2]/dx[2];//No BC.
+
         } else {
             amrex::Abort("Wrong flag of the lower polarization boundary condition!!");
             return 0.0;
@@ -437,7 +446,10 @@ using namespace FerroX;
         } else if (P_BC_flag_hi[2] == 2){
             return ( - F(i,j,k) + F(i,j,k-1))/dx[2]/dx[2];//dPdz = 0.
 
-        } else {
+        } else if (P_BC_flag_hi[2] == 3){
+            return (F(i,j,k+1) - 2.*F(i,j,k) + F(i,j,k-1))/dx[2]/dx[2];//No BC
+
+	} else {
             amrex::Abort("Wrong flag of the higher polarization boundary condition!!");
             return 0.0;
         }

--- a/Source/Solver/ElectrostaticSolver.H
+++ b/Source/Solver/ElectrostaticSolver.H
@@ -47,6 +47,8 @@ void ComputePoissonRHS_Newton(MultiFab& PoissonRHS,
                               MultiFab& PoissonPhi, 
                               MultiFab& alpha_cc);
 
+void SetPhiBC_z(MultiFab& PossonPhi, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell);
+
 void SetPoissonBC(c_FerroX& rFerroX, std::array<std::array<amrex::LinOpBCType,AMREX_SPACEDIM>,2>& LinOpBCType_2d, bool& all_homogeneous_boundaries, bool& some_functionbased_inhomogeneous_boundaries, bool& some_constant_inhomogeneous_boundaries);
 
 void Fill_Constant_Inhomogeneous_Boundaries(c_FerroX& rFerroX, MultiFab& PoissonPhi);

--- a/Source/Solver/ElectrostaticSolver.cpp
+++ b/Source/Solver/ElectrostaticSolver.cpp
@@ -406,4 +406,22 @@ void Fill_FunctionBased_Inhomogeneous_Boundaries(c_FerroX& rFerroX, MultiFab& Po
     }
 }
 
+void SetPhiBC_z(MultiFab& PoissonPhi, const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell)
+{
+    for (MFIter mfi(PoissonPhi); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.growntilebox(1);
+
+        const Array4<Real>& Phi = PoissonPhi.array(mfi);
+
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+        {
+          if(k < 0) {
+            Phi(i,j,k) = Phi_Bc_lo;
+          } else if(k >= n_cell[2]){
+            Phi(i,j,k) = Phi_Bc_hi;
+          }
+        });
+    }
+}
 

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -70,7 +70,7 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
 
                } else if (prob_type == 2) { // 3D : Initialize random P
 
-                 pOld_z(i,j,k) = (-1.0 + 2.0*Random(engine))*0.002;
+                 pOld_z(i,j,k) = (-1.0 + 2.0*Random(engine))*0.; //0.002;
 
                } else if (prob_type == 3) { // smooth P for convergence tests
 

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -70,7 +70,7 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
 
                } else if (prob_type == 2) { // 3D : Initialize random P
 
-                 pOld_z(i,j,k) = (-1.0 + 2.0*Random(engine))*0.; //0.002;
+                 pOld_z(i,j,k) = (-1.0 + 2.0*Random(engine))*0.002;
 
                } else if (prob_type == 3) { // smooth P for convergence tests
 


### PR DESCRIPTION
This PR implements a criterion for checking if the steady-state has reached:

`(Phi_{n} - Phi_{n-1}).norm0() < phi_tolerance`

Default value of phi_tolerance = 1.e-7.

It can be overwritten by the user in the input script.

Test input script: [inputs_mfim_2d.txt](https://github.com/AMReX-Microelectronics/FerroX/files/11558665/inputs_mfim_2d.txt)

Screenshot of stdout at the end:
<img width="453" alt="Screen Shot 2023-05-24 at 1 12 14 PM" src="https://github.com/AMReX-Microelectronics/FerroX/assets/89051199/f3d9f93c-d163-40e1-8743-9f7f75786d56">

Simulation reaches steady state at `step = 1067` when `error = 9.971617631e-08`

Final plotfile written is `plt00001067`.