### PR TITLE
Random initialization of P in 2D

### DIFF
--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -220,6 +220,8 @@ AMREX_GPU_MANAGED int FerroX::TimeIntegratorOrder;
 
 AMREX_GPU_MANAGED amrex::Real FerroX::delta;
 
+AMREX_GPU_MANAGED int FerroX::random_seed;
+
 void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi) {
 
@@ -285,6 +287,9 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
 
      delta = 1.e-6;
      pp.query("delta",delta);
+
+     random_seed = 1;
+     pp.query("random_seed",random_seed);
 
      //stack dimensions in 3D. This is an alternate way of initializing the device geometry, which works in simpler scenarios.
      //A more general way of initializing device geometry is accomplished through masks which use function parsers

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -59,4 +59,6 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED int TimeIntegratorOrder;
 
     extern AMREX_GPU_MANAGED amrex::Real delta;
+
+    extern AMREX_GPU_MANAGED int random_seed;
 }

--- a/Source/Solver/Initialization.H
+++ b/Source/Solver/Initialization.H
@@ -13,6 +13,7 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
                    MultiFab&   e_den,
                    MultiFab&   p_den,
 		   const MultiFab& MaterialMask,
+                   const amrex::GpuArray<int, AMREX_SPACEDIM>& n_cell,
                    const       Geometry& geom,
 		   const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                    const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -242,7 +242,7 @@ void main_main (c_FerroX& rFerroX)
     // INITIALIZE P in FE and rho in SC regions
 
     //InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, geom, prob_lo, prob_hi);//old
-    InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, MaterialMask, geom, prob_lo, prob_hi);//mask based
+    InitializePandRho(P_old, Gamma, charge_den, e_den, hole_den, MaterialMask, n_cell, geom, prob_lo, prob_hi);//mask based
     
 
     //Obtain self consisten Phi and rho


### PR DESCRIPTION
This PR implements a random initialization of Polarization for 2D problems. Prior to this we were initializing P using a deterministic approach.

**Old way:**

```
double tmp = (i%3 + k%4)/5.;
pOld_z(i,j,k) = (-1.0 + 2.0*tmp)*0.002;
```

**New way:**
```
pOld_z(i,j,k) = (-1.0 + 2.0*rng[i + k*n_cell[2]])*0.002;
```
where `rng` is a 2D array filled with uniform random numbers between `0` and `1`.