### PR TITLE
Fix rho

### DIFF
--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -206,6 +206,9 @@ AMREX_GPU_MANAGED amrex::Real FerroX::kb;
 AMREX_GPU_MANAGED amrex::Real FerroX::T;
 AMREX_GPU_MANAGED amrex::Real FerroX::acceptor_doping;
 AMREX_GPU_MANAGED amrex::Real FerroX::donor_doping;
+AMREX_GPU_MANAGED amrex::Real FerroX::intrinsic_carrier_concentration;
+
+AMREX_GPU_MANAGED int FerroX::use_Fermi_Dirac;
 
 // P and Phi Bc
 AMREX_GPU_MANAGED amrex::Real FerroX::lambda;
@@ -439,7 +442,12 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
      pp.query("acceptor_doping",acceptor_doping);
      donor_doping = 0.0;
      pp.query("donor_doping",donor_doping);
+     intrinsic_carrier_concentration = 9.696e+15;
+     pp.query("intrinsic_carrier_concentration",intrinsic_carrier_concentration);
 
+     use_Fermi_Dirac = 0;
+     pp.query("use_Fermi_Dirac",use_Fermi_Dirac);
+     
      Coordinate_Transformation = 0;
      pp.query("Coordinate_Transformation",Coordinate_Transformation);
      

--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -207,7 +207,6 @@ AMREX_GPU_MANAGED amrex::Real FerroX::T;
 AMREX_GPU_MANAGED amrex::Real FerroX::acceptor_doping;
 AMREX_GPU_MANAGED amrex::Real FerroX::donor_doping;
 AMREX_GPU_MANAGED amrex::Real FerroX::intrinsic_carrier_concentration;
-
 AMREX_GPU_MANAGED int FerroX::use_Fermi_Dirac;
 
 // P and Phi Bc
@@ -442,6 +441,7 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
      pp.query("acceptor_doping",acceptor_doping);
      donor_doping = 0.0;
      pp.query("donor_doping",donor_doping);
+
      intrinsic_carrier_concentration = 9.696e+15;
      pp.query("intrinsic_carrier_concentration",intrinsic_carrier_concentration);
 

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -45,6 +45,9 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED amrex::Real T;
     extern AMREX_GPU_MANAGED amrex::Real acceptor_doping;
     extern AMREX_GPU_MANAGED amrex::Real donor_doping;
+    extern AMREX_GPU_MANAGED amrex::Real intrinsic_carrier_concentration;
+    extern AMREX_GPU_MANAGED int use_Fermi_Dirac;
+    
 
     // P and Phi Bc
     extern AMREX_GPU_MANAGED amrex::Real lambda;

--- a/Source/Solver/ElectrostaticSolver.cpp
+++ b/Source/Solver/ElectrostaticSolver.cpp
@@ -102,7 +102,7 @@ void dF_dPhi(MultiFab&            alpha_cc,
         PoissonPhi_plus_delta.plus(delta, 0, 1, 0); 
 
         // Calculate rho from Phi in SC region
-        ComputeRho(PoissonPhi, rho, e_den, p_den, MaterialMask);
+        ComputeRho(PoissonPhi_plus_delta, rho, e_den, p_den, MaterialMask);
 
         //Compute RHS of Poisson equation
         ComputePoissonRHS(PoissonRHS_phi_plus_delta, P_old, rho, MaterialMask, angle_alpha, angle_beta, angle_theta, geom);

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -134,41 +134,42 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
              //SC region
              if (mask(i,j,k) >= 2.0) {
 
-                  Real Phi = 0.5*(Ec + Ev); //eV
-//                hole_den_arr(i,j,k) = Nv*exp(-(Phi - Ev)*1.602e-19/(kb*T));
-//                e_den_arr(i,j,k) = Nc*exp(-(Ec - Phi)*1.602e-19/(kb*T));
-//                charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k));
+                if(use_Fermi_Dirac == 1){
+                  
+                   //Approximate FD integral
+                   Real Phi = 0.5*(Ec + Ev); //eV
+                   Real eta_n = q*(Phi - Ec)/(kb*T);
+                   Real nu_n = std::pow(eta_n, 4.0) + 50.0 + 33.6 * eta_n * (1 - 0.68 * exp(-0.17 * std::pow((eta_n + 1), 2.0)));
+                   Real xi_n = 3.0 * sqrt(3.14)/(4.0 * std::pow(nu_n, 3/8));
+                   Real FD_half_n = std::pow(exp(-eta_n) + xi_n, -1.0);
 
-                  //Approximate FD integral
-                  Real eta_n = q*(Phi - Ec)/(kb*T);
-                  Real nu_n = std::pow(eta_n, 4.0) + 50.0 + 33.6 * eta_n * (1 - 0.68 * exp(-0.17 * std::pow((eta_n + 1), 2.0)));
-                  Real xi_n = 3.0 * sqrt(3.14)/(4.0 * std::pow(nu_n, 3/8));
-                  Real FD_half_n = std::pow(exp(-eta_n) + xi_n, -1.0);
+                   e_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nc*FD_half_n;
 
-                  e_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nc*FD_half_n;
+                   Real eta_p = q*(Ev - Phi)/(kb*T);
+                   Real nu_p = std::pow(eta_p, 4.0) + 50.0 + 33.6 * eta_p * (1 - 0.68 * exp(-0.17 * std::pow((eta_p + 1), 2.0)));
+                   Real xi_p = 3.0 * sqrt(3.14)/(4.0 * std::pow(nu_p, 3/8));
+                   Real FD_half_p = std::pow(exp(-eta_p) + xi_p, -1.0);
 
-                  Real eta_p = q*(Ev - Phi)/(kb*T);
-                  Real nu_p = std::pow(eta_p, 4.0) + 50.0 + 33.6 * eta_p * (1 - 0.68 * exp(-0.17 * std::pow((eta_p + 1), 2.0)));
-                  Real xi_p = 3.0 * sqrt(3.14)/(4.0 * std::pow(nu_p, 3/8));
-                  Real FD_half_p = std::pow(exp(-eta_p) + xi_p, -1.0);
+                   hole_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nv*FD_half_p;
+           
+                } else {
 
-                  hole_den_arr(i,j,k) = 2.0/sqrt(3.14)*Nv*FD_half_p;
+                   hole_den_arr(i,j,k) = intrinsic_carrier_concentration;
+                   e_den_arr(i,j,k) = intrinsic_carrier_concentration;
 
-		  //If in channel, set acceptor doping, else (Source/Drain) set donor doping
-                  if (mask(i,j,k) == 3.0) {
-		     acceptor_den_arr(i,j,k) = acceptor_doping; 
-	             donor_den_arr(i,j,k) = 0.0;
-		  } else { // Source / Drain
-		     acceptor_den_arr(i,j,k) = 0.0; 
-	             donor_den_arr(i,j,k) = donor_doping;
-		  }
-                  charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k) - acceptor_den_arr(i,j,k) + donor_den_arr(i,j,k));
-
-             } else {
-
-                charge_den_arr(i,j,k) = 0.0;
-
+                }
              }
+
+      	      //If in channel, set acceptor doping, else (Source/Drain) set donor doping
+              if (mask(i,j,k) == 3.0) {
+      	           acceptor_den_arr(i,j,k) = acceptor_doping; 
+                   donor_den_arr(i,j,k) = 0.0;
+              } else { // Source / Drain
+		   acceptor_den_arr(i,j,k) = 0.0; 
+	           donor_den_arr(i,j,k) = donor_doping;
+	      }
+              charge_den_arr(i,j,k) = q*(hole_den_arr(i,j,k) - e_den_arr(i,j,k) - acceptor_den_arr(i,j,k) + donor_den_arr(i,j,k));
+
         });
     }
     for (int i = 0; i < 3; i++){

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -133,6 +133,9 @@ void main_main (c_FerroX& rFerroX)
        Initialize_Euler_angles(rFerroX, geom, angle_alpha, angle_beta, angle_theta);
     } else {
        tphaseMask.setVal(0.);
+       angle_alpha.setVal(0.);
+       angle_beta.setVal(0.);
+       angle_theta.setVal(0.);
     }
 
     //Solver for Poisson equation

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -348,6 +348,8 @@ void main_main (c_FerroX& rFerroX)
 
     int steady_state_step = 1000000; //Initialize to a large number. It will be overwritten by the time step at which steady state condition is satidfied
 
+    int sign = 1; //change sign to -1*sign whenever abs(Phi_Bc_hi) == Phi_Bc_hi_max to do triangular wave sweep
+    
     for (int step = 1; step <= nsteps; ++step)
     {
         Real step_strt_time = ParallelDescriptor::second();
@@ -587,7 +589,7 @@ void main_main (c_FerroX& rFerroX)
 
 	   amrex::Print() << "Applied voltage updated at time " << time << ", step = " << step << "\n";
            
-            Phi_Bc_hi += Phi_Bc_inc;
+            Phi_Bc_hi += sign*Phi_Bc_inc;
             amrex::Print() << "step = " << step << ", Phi_Bc_hi = " << Phi_Bc_hi << std::endl;
 
             // Set Dirichlet BC for Phi in z
@@ -651,6 +653,7 @@ void main_main (c_FerroX& rFerroX)
        
         }//end inc_step	
    
+        if (voltage_sweep == 1 && step == steady_state_step && std::abs(Phi_Bc_hi) == Phi_Bc_hi_max) sign *= -1;
         if (voltage_sweep == 0 && step == steady_state_step) break;
         if (voltage_sweep == 1 && Phi_Bc_hi > Phi_Bc_hi_max) break;
 


### PR DESCRIPTION
This PR fixes rho computation. Currently only Maxwell-Boltzmann is fixed and is used by default. Following input ([input_mfis.txt](https://github.com/AMReX-Microelectronics/FerroX/files/12339948/input_mfis.txt)) is used for verification against Figure 5 (a) and (b) of  [https://www.nature.com/articles/s41598-020-66313-1](https://www.nature.com/articles/s41598-020-66313-1) 

<img width="722" alt="Screenshot 2023-08-14 at 3 23 00 PM" src="https://github.com/AMReX-Microelectronics/FerroX/assets/89051199/fbc5e618-b438-49a0-b3a4-574c64848243">
