### PR TITLE
fix g11 and g44 indexing with coordinate transform

### DIFF
--- a/Source/Solver/TotalEnergyDensity.cpp
+++ b/Source/Solver/TotalEnergyDensity.cpp
@@ -109,15 +109,14 @@ void CalculateTDGL_RHS(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs,
                                   - (g12 + g44 + g44_p) * DoubleDPDxDy(pOld_p, mask, i, j, k, dx) // d2P/dxdy
                                   - (g12 + g44 - g44_p) * DoubleDPDyDz(pOld_r, mask, i, j, k, dx);// d2P/dydz
 
-		//Switch g11 and g44 temporarily for multiphase simulations. This will be generalized later
-                Real dFdPr_grad = - g44 * ( R_31*R_31*DoubleDPDx(pOld_r, mask, i, j, k, dx)
+                Real dFdPr_grad = - g11 * ( R_31*R_31*DoubleDPDx(pOld_r, mask, i, j, k, dx)
                                            +R_32*R_32*DoubleDPDy(pOld_r, mask, i, j, k, dx)
                                            +R_33*R_33*DoubleDPDz(pOld_r, mask, i, j, k, dx)
                                            +2.*R_31*R_32*DoubleDPDxDy(pOld_r, mask, i, j, k, dx)
                                            +2.*R_32*R_33*DoubleDPDyDz(pOld_r, mask, i, j, k, dx)
                                            +2.*R_33*R_31*DoubleDPDxDz(pOld_r, mask, i, j, k, dx))
                                            
-                                  - (g11 - g44_p) * ( R_11*R_11*DoubleDPDx(pOld_r, mask, i, j, k, dx) 
+                                  - (g44 - g44_p) * ( R_11*R_11*DoubleDPDx(pOld_r, mask, i, j, k, dx) 
                                                      +R_12*R_12*DoubleDPDy(pOld_r, mask, i, j, k, dx) 
                                                      +R_13*R_13*DoubleDPDz(pOld_r, mask, i, j, k, dx) 
                                                      +2.*R_11*R_12*DoubleDPDxDy(pOld_r, mask, i, j, k, dx) 


### PR DESCRIPTION
In normal coordinate, 
d2Pz/dx2, d2Pz/dy2 -> g44
d2Pz/dz2 -> g11

Now the new coordinate has (p,q,r) corresponding to (x,y,z), which makes
d2Pr/dp2, d2Pr/dq2 -> g44
d2Pr/dr2 -> g11

Here are the related documents:
https://docs.google.com/document/d/1lgQL4nNJNlfiEGDrqrf7bdHotZktxLuW9y6jM66_D6Q/edit
[PxPy_PR16.pdf](https://github.com/AMReX-Microelectronics/FerroX/files/12667235/PxPy_PR16.pdf)
