### PR TITLE
vector polarization initialization

### DIFF
--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -213,9 +213,11 @@ AMREX_GPU_MANAGED int FerroX::use_Fermi_Dirac;
 AMREX_GPU_MANAGED amrex::Real FerroX::lambda;
 AMREX_GPU_MANAGED amrex::GpuArray<int, AMREX_SPACEDIM> FerroX::P_BC_flag_lo;
 AMREX_GPU_MANAGED amrex::GpuArray<int, AMREX_SPACEDIM> FerroX::P_BC_flag_hi;
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> FerroX::Remnant_P;
 
 //problem type : initialization of P for 2D/3D/convergence problems
 AMREX_GPU_MANAGED int FerroX::prob_type;
+AMREX_GPU_MANAGED int FerroX::is_polarization_scalar;
 
 AMREX_GPU_MANAGED int FerroX::mlmg_verbosity;
 
@@ -269,6 +271,9 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
      pp.get("TimeIntegratorOrder",TimeIntegratorOrder);
 
      pp.get("prob_type", prob_type);
+
+     is_polarization_scalar = 1;
+     pp.query("is_polarization_scalar",is_polarization_scalar);
 
      mlmg_verbosity = 1;
      pp.query("mlmg_verbosity",mlmg_verbosity);
@@ -367,6 +372,11 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
 	 t_phase_hi[i] = 1.0;
      }
 
+     //Default values of Remnnant Polarization
+     Remnant_P[0] = 0.0;
+     Remnant_P[1] = 0.0;
+     Remnant_P[2] = 0.002;
+
      amrex::Vector<amrex::Real> temp(AMREX_SPACEDIM);
 
      pp.getarr("FE_lo",temp);
@@ -424,6 +434,12 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
      if (pp.queryarr("t_phase_hi",temp)) {
          for (int i=0; i<AMREX_SPACEDIM; ++i) {
              t_phase_hi[i] = temp[i];
+         }
+     }
+
+     if (pp.queryarr("Remnant_P",temp)) {
+         for (int i=0; i<AMREX_SPACEDIM; ++i) {
+             Remnant_P[i] = temp[i];
          }
      }
 

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -54,9 +54,12 @@ namespace FerroX {
 
     extern AMREX_GPU_MANAGED amrex::GpuArray<int, AMREX_SPACEDIM> P_BC_flag_lo;
     extern AMREX_GPU_MANAGED amrex::GpuArray<int, AMREX_SPACEDIM> P_BC_flag_hi;
+    extern AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> Remnant_P;
+
 
     //problem type : initialization of P for 2D/3D/convergence problems
     extern AMREX_GPU_MANAGED int prob_type;
+    extern AMREX_GPU_MANAGED int is_polarization_scalar;
 
     extern AMREX_GPU_MANAGED int mlmg_verbosity;
 

--- a/Source/Solver/Initialization.cpp
+++ b/Source/Solver/Initialization.cpp
@@ -85,15 +85,21 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
             if (mask(i,j,k) == 0.0) { //FE mask is 0.0
                if (prob_type == 1) {  //2D : Initialize uniform P in y direction
 
-                 pOld_r(i,j,k) = (-1.0 + 2.0*rng[i + k*n_cell[2]])*0.002;
+                 pOld_p(i,j,k) = (-1.0 + 2.0*rng[i + k*n_cell[2]])*Remnant_P[0];
+                 pOld_q(i,j,k) = (-1.0 + 2.0*rng[i + k*n_cell[2]])*Remnant_P[1];
+                 pOld_r(i,j,k) = (-1.0 + 2.0*rng[i + k*n_cell[2]])*Remnant_P[2];
 
                } else if (prob_type == 2) { // 3D : Initialize random P
 
-                 pOld_r(i,j,k) = (-1.0 + 2.0*Random(engine))*0.002;
+                 pOld_p(i,j,k) = (-1.0 + 2.0*Random(engine))*Remnant_P[0];
+                 pOld_q(i,j,k) = (-1.0 + 2.0*Random(engine))*Remnant_P[1];
+                 pOld_r(i,j,k) = (-1.0 + 2.0*Random(engine))*Remnant_P[2];
 
                } else if (prob_type == 3) { // smooth P for convergence tests
 
-                 pOld_r(i,j,k) = 0.002*exp(-(x*x/(2.0*5.e-9*5.e-9) + y*y/(2.0*5.e-9*5.e-9) + (z-1.5*DE_hi[2])*(z - 1.5*DE_hi[2])/(2.0*2.0e-9*2.0e-9)));
+                 pOld_p(i,j,k) = Remnant_P[0]*exp(-(x*x/(2.0*5.e-9*5.e-9) + y*y/(2.0*5.e-9*5.e-9) + (z-1.5*DE_hi[2])*(z - 1.5*DE_hi[2])/(2.0*2.0e-9*2.0e-9)));
+                 pOld_q(i,j,k) = Remnant_P[1]*exp(-(x*x/(2.0*5.e-9*5.e-9) + y*y/(2.0*5.e-9*5.e-9) + (z-1.5*DE_hi[2])*(z - 1.5*DE_hi[2])/(2.0*2.0e-9*2.0e-9)));
+                 pOld_r(i,j,k) = Remnant_P[2]*exp(-(x*x/(2.0*5.e-9*5.e-9) + y*y/(2.0*5.e-9*5.e-9) + (z-1.5*DE_hi[2])*(z - 1.5*DE_hi[2])/(2.0*2.0e-9*2.0e-9)));
 
                } else {
 
@@ -110,11 +116,16 @@ void InitializePandRho(Array<MultiFab, AMREX_SPACEDIM> &P_old,
 	       }
 
             } else {
+               pOld_p(i,j,k) = 0.0;
+               pOld_q(i,j,k) = 0.0;
                pOld_r(i,j,k) = 0.0;
                Gam(i,j,k) = 0.0;
             }
-            pOld_p(i,j,k) = 0.0;
-            pOld_q(i,j,k) = 0.0;
+
+	    if (is_polarization_scalar == 1){
+               pOld_p(i,j,k) = 0.0;
+               pOld_q(i,j,k) = 0.0;
+	    }
         });
         // Calculate charge density from Phi, Nc, Nv, Ec, and Ev
 

--- a/Source/Solver/TotalEnergyDensity.cpp
+++ b/Source/Solver/TotalEnergyDensity.cpp
@@ -133,33 +133,35 @@ void CalculateTDGL_RHS(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs,
                                   - (g44 + g44_p + g12) * DoubleDPDyDz(pOld_q, mask, i, j, k, dx) // d2P/dydz
                                   - (g44 + g44_p + g12) * DoubleDPDxDz(pOld_p, mask, i, j, k, dx); // d2P/dxdz
 
-                GL_RHS_p(i,j,k)  = -1.0 * Gam(i,j,k) *
+                GL_RHS_p(i,j,k) = -1.0 * Gam(i,j,k) *
                     (  dFdPp_Landau
                      + dFdPp_grad
 		     - Ep(i,j,k)
-                     //+ DFDx(phi, i, j, k, dx)
                     );
 
-                GL_RHS_q(i,j,k)  = -1.0 * Gam(i,j,k) *
+                GL_RHS_q(i,j,k) = -1.0 * Gam(i,j,k) *
                     (  dFdPq_Landau
                      + dFdPq_grad
 		     - Eq(i,j,k)
-                     //+ DFDy(phi, i, j, k, dx)
                     );
 
-		GL_RHS_p(i,j,k)  = 0.0;
-		GL_RHS_q(i,j,k)  = 0.0;
-                GL_RHS_r(i,j,k)  = -1.0 * Gam(i,j,k) *
+                GL_RHS_r(i,j,k) = -1.0 * Gam(i,j,k) *
                     (  dFdPr_Landau
                      + dFdPr_grad
 		     - Er(i,j,k)
-                     //+ DphiDz(phi, z_hi, z_lo, i, j, k, dx, prob_lo, prob_hi)
                     );
+
+                if (is_polarization_scalar == 1){
+		   GL_RHS_p(i,j,k) = 0.0;
+		   GL_RHS_q(i,j,k) = 0.0;
+		}
 
 		//set t_phase GL_RHS_r to zero so that it stays zero. It is initialized to zero in t-phase as well
                 //if(x <= t_phase_hi[0] && x >= t_phase_lo[0] && y <= t_phase_hi[1] && y >= t_phase_lo[1] && z <= t_phase_hi[2] && z >= t_phase_lo[2]){
-                if(tphase(i,j,k) == 1.0){
-                  GL_RHS_r(i,j,k) = 0.0;
+                if (tphase(i,j,k) == 1.0){
+		   GL_RHS_p(i,j,k) = 0.0;
+		   GL_RHS_q(i,j,k) = 0.0;
+		   GL_RHS_r(i,j,k) = 0.0;
                 }
             });
         }


### PR DESCRIPTION
This PR adds the option to initialize **P** with a user defined remnant polarization value called `Remnant_P`. 

`Remnant_P`  takes three real numbers to represent `x`, `y`, and `z` components of initial remnant polarization.    

It is an optional parameter. The default values are

```Remnant_P = 0.0 0.0 0.002```

This PR also adds a new optional parameter called `is_polarization_scalar` which takes an integer. The default values is : 
``` is_polarization_scalar = 1```

In order to use the vector polarization model (i.e. non-zero Px, Py, and Pz, we need to set ``` is_polarization_scalar = 0``` ). When `is_polarization_scalar = 1`, we also set `TDGL_RHS_x(y) = 0.0`, so that `Px` and `Py` stay zero at all times.

Note that, the default values for these new input params are set in such a way that all the previous input files should work without any modifications.
