### PR TITLE
SUNDIALS v7.1.1. instructions

### DIFF
--- a/Exec/README_sundials
+++ b/Exec/README_sundials
@@ -3,13 +3,19 @@ https://computing.llnl.gov/projects/sundials/faq#inst
 
 Installation
 
-# Download sundials-x.y.z.tar.gz file for SUNDIALS and extract it at the same level as amrex.
-# Update 6/11/24 - v7.0.0. tested
-https://computing.llnl.gov/projects/sundials/sundials-software
-
+# You need SUNDIALS v7.1.1 or later.
+# Check https://computing.llnl.gov/projects/sundials/sundials-software to see if it's available for download.
+# If so, download sundials-x.y.z.tar.gz and extract it at the same level as amrex using
 >> tar -xzvf sundials-x.y.z.tar.gz # where x.y.z is the version of sundials
+>> mv sundials-x.y.z sundials-src
 
-# at the same level that amrex is cloned, do:
+# If v7.1.1. is not available on the website, clone the git repo directly and use the latest version
+# At the same level that amrex is cloned, do:
+
+>> git clone https://github.com/LLNL/sundials.git
+>> mv sundials sundials-src
+
+# Next
 
 >> mkdir sundials
 >> cd sundials
@@ -22,7 +28,7 @@ HOST BUILD
 >> mkdir builddir
 >> cd builddir
 
->> cmake -DCMAKE_INSTALL_PREFIX=/pathto/sundials/instdir -DEXAMPLES_INSTALL_PATH=/pathto/sundials/instdir/examples -DENABLE_MPI=ON ../../sundials-x.y.z
+>> cmake -DCMAKE_INSTALL_PREFIX=/pathto/sundials/instdir -DEXAMPLES_INSTALL_PATH=/pathto/sundials/instdir/examples -DENABLE_MPI=ON ../../sundials-src
 
 ######################
 NVIDIA/CUDA BUILD
@@ -34,7 +40,7 @@ NVIDIA/CUDA BUILD
 >> mkdir builddir_cuda
 >> cd builddir_cuda
 
->> cmake -DCMAKE_INSTALL_PREFIX=/pathto/sundials/instdir_cuda -DEXAMPLES_INSTALL_PATH=/pathto/sundials/instdir_cuda/examples -DENABLE_CUDA=ON -DENABLE_MPI=ON ../../sundials-x.y.z
+>> cmake -DCMAKE_INSTALL_PREFIX=/pathto/sundials/instdir_cuda -DEXAMPLES_INSTALL_PATH=/pathto/sundials/instdir_cuda/examples -DENABLE_CUDA=ON -DENABLE_MPI=ON ../../sundials-src
 
 ######################
 


### PR DESCRIPTION
SUNDIALS v7.1.0 or greater is needed to support our interface (v7.1.1 is the latest)
However v.7.1.0 is not posted on the website yet so I have also included alternative instructions that involve cloning the SUNDIALS git repo directly.  As of 7/15/24 the main branch is the 7.1.1 tag.
I verified these instructions work with the amrex-tutorial for FE and RK4 via the ERK interface.