### PR TITLE
multi-rate time integration using sundials

### DIFF
--- a/Exec/inputs_mfim_sundials
+++ b/Exec/inputs_mfim_sundials
@@ -1,0 +1,110 @@
+#################################
+###### PROBLEM DOMAIN ######
+#################################
+
+domain.prob_lo = -16.e-9 -16.e-9 0.e-9
+domain.prob_hi =  16.e-9  16.e-9 9.e-9
+
+domain.n_cell = 64 64 18
+
+domain.max_grid_size = 64 64 18
+
+domain.coord_sys = cartesian 
+
+prob_type = 1
+
+TimeIntegratorOrder = 1
+
+nsteps = 1000
+plot_int = 100
+
+dt = 4.0e-13
+
+############################################
+###### POLARIZATION BOUNDARY CONDITIONS ####
+############################################
+
+P_BC_flag_lo = 3 3 0
+P_BC_flag_hi = 3 3 1
+lambda = 3.0e-9
+
+############################################
+###### ELECTRICAL BOUNDARY CONDITIONS ######
+############################################
+
+domain.is_periodic = 1 1 0
+
+boundary.hi = per per dir(0.0)
+boundary.lo = per per dir(0.0)
+
+Phi_Bc_lo = 0.0
+Phi_Bc_hi = 0.0
+
+inc_step = 5000
+Phi_Bc_inc = 0.0
+
+#################################
+###### STACK GEOMETRY ###########
+#################################
+
+SC_lo = -1.0 -1.0 -1.0
+SC_hi = -1.0 -1.0 -1.0
+
+DE_lo = -16.e-9 -16.e-9 0.0e-9
+DE_hi =  16.e-9  16.e-9 4.0e-9
+
+FE_lo = -16.e-9 -16.e-9 4.0e-9
+FE_hi =  16.e-9  16.e-9 9.e-9
+
+#################################
+###### MATERIAL PROPERTIES ######
+#################################
+
+epsilon_0 = 8.85e-12
+epsilonX_fe = 24.0
+epsilonZ_fe = 24.0
+epsilon_de = 10.0
+epsilon_si = 11.7
+alpha = -2.5e9
+beta = 6.0e10
+gamma = 1.5e11
+BigGamma = 100
+g11 = 1.0e-9
+g44 = 1.0e-9
+g44_p = 0.0
+g12 = 0.0
+alpha_12 = 0.0
+alpha_112 = 0.0
+alpha_123 = 0.0
+
+#################################
+###### INTEGRATION ##############
+#################################
+use_sundials = 1
+using_MRI = 0
+fast_Grad = 0
+fast_dt_ratio = 0.2
+
+## amrex/sundials backend integrators
+## *** Selecting the integrator backend ***
+## integration.type can take on the following string or int values:
+## (without the quotation marks)
+## "ForwardEuler" or "0" = Native Forward Euler Integrator
+## "RungeKutta" or "1"   = Native Explicit Runge Kutta controlled by integration.rk.type
+## "SUNDIALS" or "2"     = SUNDIALS Integrators controlled by integration.sundials.strategy
+integration.type = SUNDIALS
+
+## *** Parameters Needed For Native Explicit Runge-Kutta ***
+#
+## integration.rk.type can take the following values:
+### 0 = User-specified Butcher Tableau
+### 1 = Forward Euler
+### 2 = Trapezoid Method
+### 3 = SSPRK3 Method
+### 4 = RK4 Method
+#integration.rk.type = 1
+
+integration.sundials.type = ERK
+
+integration.sundials.method = ARKODE_MIS_KW3
+

--- a/Exec/inputs_mfim_sundials_mri
+++ b/Exec/inputs_mfim_sundials_mri
@@ -1,0 +1,114 @@
+#################################
+###### PROBLEM DOMAIN ######
+#################################
+
+domain.prob_lo = -16.e-9 -16.e-9 0.e-9
+domain.prob_hi =  16.e-9  16.e-9 9.e-9
+
+domain.n_cell = 64 64 18
+
+domain.max_grid_size = 64 64 18
+
+domain.coord_sys = cartesian 
+
+prob_type = 1
+
+TimeIntegratorOrder = 1
+
+nsteps = 200
+plot_int = 20
+
+dt = 2.0e-12
+
+############################################
+###### POLARIZATION BOUNDARY CONDITIONS ####
+############################################
+
+P_BC_flag_lo = 3 3 0
+P_BC_flag_hi = 3 3 1
+lambda = 3.0e-9
+
+############################################
+###### ELECTRICAL BOUNDARY CONDITIONS ######
+############################################
+
+domain.is_periodic = 1 1 0
+
+boundary.hi = per per dir(0.0)
+boundary.lo = per per dir(0.0)
+
+Phi_Bc_lo = 0.0
+Phi_Bc_hi = 0.0
+
+inc_step = 5000
+Phi_Bc_inc = 0.0
+
+#################################
+###### STACK GEOMETRY ###########
+#################################
+
+SC_lo = -1.0 -1.0 -1.0
+SC_hi = -1.0 -1.0 -1.0
+
+DE_lo = -16.e-9 -16.e-9 0.0e-9
+DE_hi =  16.e-9  16.e-9 4.0e-9
+
+FE_lo = -16.e-9 -16.e-9 4.0e-9
+FE_hi =  16.e-9  16.e-9 9.e-9
+
+#################################
+###### MATERIAL PROPERTIES ######
+#################################
+
+epsilon_0 = 8.85e-12
+epsilonX_fe = 24.0
+epsilonZ_fe = 24.0
+epsilon_de = 10.0
+epsilon_si = 11.7
+alpha = -2.5e9
+beta = 6.0e10
+gamma = 1.5e11
+BigGamma = 100
+g11 = 1.0e-9
+g44 = 1.0e-9
+g44_p = 0.0
+g12 = 0.0
+alpha_12 = 0.0
+alpha_112 = 0.0
+alpha_123 = 0.0
+
+#################################
+###### INTEGRATION ##############
+#################################
+use_sundials = 1
+using_MRI = 1
+fast_Grad = 1
+fast_dt_ratio = 0.2
+
+## amrex/sundials backend integrators
+## *** Selecting the integrator backend ***
+## integration.type can take on the following string or int values:
+## (without the quotation marks)
+## "ForwardEuler" or "0" = Native Forward Euler Integrator
+## "RungeKutta" or "1"   = Native Explicit Runge Kutta controlled by integration.rk.type
+## "SUNDIALS" or "2"     = SUNDIALS Integrators controlled by integration.sundials.strategy
+integration.type = SUNDIALS
+
+## *** Parameters Needed For Native Explicit Runge-Kutta ***
+#
+## integration.rk.type can take the following values:
+### 0 = User-specified Butcher Tableau
+### 1 = Forward Euler
+### 2 = Trapezoid Method
+### 3 = SSPRK3 Method
+### 4 = RK4 Method
+#integration.rk.type = 1
+
+#integration.sundials.type = ERK
+integration.sundials.type = EX-MRI
+
+integration.sundials.method = ARKODE_MIS_KW3
+
+integration.sundials.fast_type = ERK  # ERK or DIRK
+integration.sundials.fast_method = ARKODE_KNOTH_WOLKE_3_3
+

--- a/Source/FerroX.cpp
+++ b/Source/FerroX.cpp
@@ -260,6 +260,15 @@ AMREX_GPU_MANAGED amrex::Real FerroX::Phi_Bc_hi_max;
 AMREX_GPU_MANAGED amrex::Real FerroX::phi_tolerance;
 AMREX_GPU_MANAGED int FerroX::random_seed;
 AMREX_GPU_MANAGED int FerroX::num_Vapp_max; //Maximum number of applied voltage points to sweep
+AMREX_GPU_MANAGED int FerroX::include_Landau;
+AMREX_GPU_MANAGED int FerroX::include_Grad;
+AMREX_GPU_MANAGED int FerroX::include_Elec;
+
+AMREX_GPU_MANAGED int FerroX::using_MRI;
+AMREX_GPU_MANAGED int FerroX::fast_Landau;
+AMREX_GPU_MANAGED int FerroX::fast_Grad;
+AMREX_GPU_MANAGED int FerroX::fast_Elec;
+AMREX_GPU_MANAGED amrex::Real FerroX::fast_dt_ratio;
 
 void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
                                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi) {
@@ -402,6 +411,30 @@ void InitializeFerroXNamespace(const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM
 
      num_Vapp_max = 1;
      pp.query("num_Vapp_max",num_Vapp_max);
+
+     include_Landau = 1;
+     pp.query("include_Landau",include_Landau);
+
+     include_Grad = 1;
+     pp.query("include_Grad",include_Grad);
+
+     include_Elec = 1;
+     pp.query("include_Elec",include_Elec);
+
+     using_MRI = 0;
+     pp.query("using_MRI",using_MRI);
+     
+     fast_Landau = 0;
+     pp.query("fast_Landau",fast_Landau);
+
+     fast_Grad = 0;
+     pp.query("fast_Grad",fast_Grad);
+
+     fast_Elec = 0;
+     pp.query("fast_Elec",fast_Elec);
+
+     fast_dt_ratio = 0.1;
+     pp.query("fast_dt_ratio",fast_dt_ratio);
 
      //stack dimensions in 3D. This is an alternate way of initializing the device geometry, which works in simpler scenarios.
      //A more general way of initializing device geometry is accomplished through masks which use function parsers

--- a/Source/FerroX_namespace.H
+++ b/Source/FerroX_namespace.H
@@ -103,4 +103,13 @@ namespace FerroX {
     extern AMREX_GPU_MANAGED int num_Vapp_max;
 
     extern AMREX_GPU_MANAGED int random_seed;
+    
+    extern AMREX_GPU_MANAGED int include_Landau;
+    extern AMREX_GPU_MANAGED int include_Grad;
+    extern AMREX_GPU_MANAGED int include_Elec;
+    extern AMREX_GPU_MANAGED int fast_Landau;
+    extern AMREX_GPU_MANAGED int fast_Grad;
+    extern AMREX_GPU_MANAGED int fast_Elec;
+    extern AMREX_GPU_MANAGED int using_MRI;
+    extern AMREX_GPU_MANAGED amrex::Real fast_dt_ratio;
 }

--- a/Source/Solver/TotalEnergyDensity.H
+++ b/Source/Solver/TotalEnergyDensity.H
@@ -7,12 +7,33 @@ using namespace amrex;
 using namespace FerroX;
 
 void CalculateTDGL_RHS(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs,
+                Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_Landau,
+                Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_grad,
+                Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_elec,
                 Array<MultiFab, AMREX_SPACEDIM> &P_old,
-                Array<MultiFab, AMREX_SPACEDIM> &E,
+                Array<MultiFab, AMREX_SPACEDIM> &E, 
                 MultiFab&                       Gamma,
-                MultiFab&                       MaterialMask,
-                MultiFab&                       tphaseMask,
+                MultiFab&                 MaterialMask,
+                MultiFab&                 tphaseMask,
                 MultiFab& angle_alpha, MultiFab& angle_beta, MultiFab& angle_theta,
-                const Geometry& geom,
-		const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_lo,
-                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& prob_hi);
+                const Geometry& geom);
+
+void Calculate_Landau(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_Landau,
+                Array<MultiFab, AMREX_SPACEDIM> &P_old,
+                MultiFab&                       Gamma,
+                MultiFab&                 tphaseMask);
+
+void Calculate_Grad(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_grad,
+                Array<MultiFab, AMREX_SPACEDIM> &P_old, 
+                MultiFab&                       Gamma,
+                MultiFab&                 MaterialMask,
+                MultiFab&                 tphaseMask,
+                MultiFab& angle_alpha, MultiFab& angle_beta, MultiFab& angle_theta,
+                const Geometry& geom);
+
+void Calculate_Elec(Array<MultiFab, AMREX_SPACEDIM> &GL_rhs_elec,
+                Array<MultiFab, AMREX_SPACEDIM> &E, 
+                MultiFab&                       Gamma,
+                MultiFab&                 tphaseMask);
+
+


### PR DESCRIPTION
This PR adds multi-rate time integration support using SUNDIALS library.

Code compiles, runs, and gives correct answers using both single rate and multi rate options.

I have added two input files which I used to test :

1. `inputs_mfim_sundials ` for single rate method
2. `inputs_mfim_sundials_mri` for multi-rate method

Result at same physical time using the two input files are shown below:
**Using single rate method**
<img width="858" alt="image" src="https://github.com/user-attachments/assets/47627285-f6be-4851-a646-4b69e922c27e">

**Using multi-rate method**
<img width="876" alt="image" src="https://github.com/user-attachments/assets/fec480aa-61f4-4cdd-b0d8-ed41ced267cb">

I am able to use a 5x larger time step with MRI [will check if I can increase it even more].

Overall simulation time to reach same physical time of 4e-10 s:
single rate: 1861.619992 seconds
multi rate : 415.7616465 seconds

So, MRI is roughly **4.5 x faster** than single rate for the above test.
